### PR TITLE
Rename event names to follow a more widely used naming convention

### DIFF
--- a/packages/drop-in/src/apis/commercelayer/cart.ts
+++ b/packages/drop-in/src/apis/commercelayer/cart.ts
@@ -1,6 +1,6 @@
 import { createClient, getAccessToken } from '#apis/commercelayer/client'
 import { getConfig } from '#apis/commercelayer/config'
-import { dispatchEvent } from '#apis/event'
+import { fireEvent } from '#apis/event'
 import { getKeyForCart } from '#apis/storage'
 import type {
   AddItem,
@@ -133,7 +133,7 @@ export const triggerCartUpdate: TriggerCartUpdate = async () => {
   const order = await getCart()
 
   if (order !== null) {
-    dispatchEvent('cl-cart-update', [], order)
+    fireEvent('cl-cart-update', [], order)
   }
 
   return order
@@ -153,7 +153,7 @@ export const triggerHostedCartUpdate: TriggerHostedCartUpdate = async (
   const order = await getCart()
 
   if (order !== null) {
-    dispatchEvent('cl-cart-hostedcartupdate', [iframeId], order)
+    fireEvent('cl-cart-hostedcartupdate', [iframeId], order)
   }
 
   return order
@@ -173,7 +173,7 @@ export const addItem: AddItem = async (sku, quantity) => {
     _update_quantity: true
   })
 
-  dispatchEvent('cl-cart-additem', [sku, quantity], lineItem)
+  fireEvent('cl-cart-additem', [sku, quantity], lineItem)
 
   if (getCart.cache.clear !== undefined) {
     getCart.cache.clear()

--- a/packages/drop-in/src/apis/commercelayer/cart.ts
+++ b/packages/drop-in/src/apis/commercelayer/cart.ts
@@ -133,7 +133,7 @@ export const triggerCartUpdate: TriggerCartUpdate = async () => {
   const order = await getCart()
 
   if (order !== null) {
-    dispatchEvent('cl.cart.update', [], order)
+    dispatchEvent('cl-cart-update', [], order)
   }
 
   return order
@@ -153,7 +153,7 @@ export const triggerHostedCartUpdate: TriggerHostedCartUpdate = async (
   const order = await getCart()
 
   if (order !== null) {
-    dispatchEvent('cl.cart.hostedCartUpdate', [iframeId], order)
+    dispatchEvent('cl-cart-hostedcartupdate', [iframeId], order)
   }
 
   return order
@@ -173,7 +173,7 @@ export const addItem: AddItem = async (sku, quantity) => {
     _update_quantity: true
   })
 
-  dispatchEvent('cl.cart.addItem', [sku, quantity], lineItem)
+  dispatchEvent('cl-cart-additem', [sku, quantity], lineItem)
 
   if (getCart.cache.clear !== undefined) {
     getCart.cache.clear()

--- a/packages/drop-in/src/apis/commercelayer/prices.ts
+++ b/packages/drop-in/src/apis/commercelayer/prices.ts
@@ -1,4 +1,4 @@
-import { dispatchEvent } from '#apis/event'
+import { fireEvent } from '#apis/event'
 import type { GetPrice } from '#apis/types'
 import { pDebounce } from '#utils/debounce'
 import { logGroup } from '#utils/logger'
@@ -61,7 +61,7 @@ const getMemoizedPrice = memoize<GetPrice>(async (sku) => {
 export const getPrice: GetPrice = async (sku) => {
   const price = await getMemoizedPrice(sku)
 
-  dispatchEvent('cl-prices-getprice', [sku], price)
+  fireEvent('cl-prices-getprice', [sku], price)
 
   return price
 }

--- a/packages/drop-in/src/apis/commercelayer/prices.ts
+++ b/packages/drop-in/src/apis/commercelayer/prices.ts
@@ -61,7 +61,7 @@ const getMemoizedPrice = memoize<GetPrice>(async (sku) => {
 export const getPrice: GetPrice = async (sku) => {
   const price = await getMemoizedPrice(sku)
 
-  dispatchEvent('cl.prices.getPrice', [sku], price)
+  dispatchEvent('cl-prices-getprice', [sku], price)
 
   return price
 }

--- a/packages/drop-in/src/apis/commercelayer/skus.ts
+++ b/packages/drop-in/src/apis/commercelayer/skus.ts
@@ -72,7 +72,7 @@ const getMemoizedSku = memoize<GetSku>(async (code) => {
 export const getSku: GetSku = async (code) => {
   const sku = await getMemoizedSku(code)
 
-  dispatchEvent('cl.skus.getSku', [code], sku)
+  dispatchEvent('cl-skus-getsku', [code], sku)
 
   return sku
 }

--- a/packages/drop-in/src/apis/commercelayer/skus.ts
+++ b/packages/drop-in/src/apis/commercelayer/skus.ts
@@ -1,4 +1,4 @@
-import { dispatchEvent } from '#apis/event'
+import { fireEvent } from '#apis/event'
 import type { GetSku, Sku } from '#apis/types'
 import { pDebounce } from '#utils/debounce'
 import { logGroup } from '#utils/logger'
@@ -72,7 +72,7 @@ const getMemoizedSku = memoize<GetSku>(async (code) => {
 export const getSku: GetSku = async (code) => {
   const sku = await getMemoizedSku(code)
 
-  dispatchEvent('cl-skus-getsku', [code], sku)
+  fireEvent('cl-skus-getsku', [code], sku)
 
   return sku
 }

--- a/packages/drop-in/src/apis/event.ts
+++ b/packages/drop-in/src/apis/event.ts
@@ -9,11 +9,11 @@ import type {
 } from './types'
 
 export interface EventTypes {
-  'cl.prices.getPrice': GetPrice
-  'cl.skus.getSku': GetSku
-  'cl.cart.addItem': AddItem
-  'cl.cart.hostedCartUpdate': NonNullableReturnType<TriggerHostedCartUpdate>
-  'cl.cart.update': NonNullableReturnType<TriggerCartUpdate>
+  'cl-prices-getprice': GetPrice
+  'cl-skus-getsku': GetSku
+  'cl-cart-additem': AddItem
+  'cl-cart-hostedcartupdate': NonNullableReturnType<TriggerHostedCartUpdate>
+  'cl-cart-update': NonNullableReturnType<TriggerCartUpdate>
 }
 
 export type CLCustomEventDetailMap = {

--- a/packages/drop-in/src/components/cl-cart-count/cl-cart-count.spec.tsx
+++ b/packages/drop-in/src/components/cl-cart-count/cl-cart-count.spec.tsx
@@ -34,15 +34,15 @@ describe('cl-cart-count.spec', () => {
     `)
   })
 
-  it('renders with updated quantity when "cl.cart.update" is triggered with order details', async () => {
+  it('renders with updated quantity when "cl-cart-update" is triggered with order details', async () => {
     const { root, waitForChanges, doc } = await newSpecPage({
       components: [ClCartCount],
       html: `<cl-cart-count></cl-cart-count>`
     })
 
     doc.dispatchEvent(
-      new CustomEvent<CLCustomEventDetailMap['cl.cart.update']>(
-        'cl.cart.update',
+      new CustomEvent<CLCustomEventDetailMap['cl-cart-update']>(
+        'cl-cart-update',
         {
           detail: {
             request: {
@@ -71,15 +71,15 @@ describe('cl-cart-count.spec', () => {
     `)
   })
 
-  it('renders as empty when "cl.cart.update" is triggered with empty order', async () => {
+  it('renders as empty when "cl-cart-update" is triggered with empty order', async () => {
     const { root, waitForChanges, doc } = await newSpecPage({
       components: [ClCartCount],
       html: `<cl-cart-count></cl-cart-count>`
     })
 
     doc.dispatchEvent(
-      new CustomEvent<CLCustomEventDetailMap['cl.cart.update']>(
-        'cl.cart.update',
+      new CustomEvent<CLCustomEventDetailMap['cl-cart-update']>(
+        'cl-cart-update',
         {
           detail: {
             request: {
@@ -100,8 +100,8 @@ describe('cl-cart-count.spec', () => {
     await waitForChanges()
 
     doc.dispatchEvent(
-      new CustomEvent<CLCustomEventDetailMap['cl.cart.update']>(
-        'cl.cart.update',
+      new CustomEvent<CLCustomEventDetailMap['cl-cart-update']>(
+        'cl-cart-update',
         {
           detail: {
             request: {

--- a/packages/drop-in/src/components/cl-cart-count/cl-cart-count.tsx
+++ b/packages/drop-in/src/components/cl-cart-count/cl-cart-count.tsx
@@ -13,11 +13,11 @@ export class ClCartCount {
   @State() count: number | undefined
 
   async componentWillLoad(): Promise<void> {
-    listenTo('cl.cart.update', (event) => {
+    listenTo('cl-cart-update', (event) => {
       void this.updateCart(event.detail.response)
     })
 
-    listenTo('cl.cart.hostedCartUpdate', (event) => {
+    listenTo('cl-cart-hostedcartupdate', (event) => {
       void this.updateCart(event.detail.response)
     })
 

--- a/packages/drop-in/src/components/cl-cart-link/cl-cart-link.tsx
+++ b/packages/drop-in/src/components/cl-cart-link/cl-cart-link.tsx
@@ -26,7 +26,7 @@ export class CLCartLink implements Props {
       this.minicart.type = 'mini'
     }
 
-    listenTo('cl.cart.update', async () => {
+    listenTo('cl-cart-update', async () => {
       if (this.href === undefined || !isValidUrl(this.href)) {
         this.href = await getCartUrl()
       }

--- a/packages/drop-in/src/components/cl-cart/cl-cart.tsx
+++ b/packages/drop-in/src/components/cl-cart/cl-cart.tsx
@@ -90,7 +90,7 @@ export class ClCart {
   private flag_justAddedToCart: boolean = false
 
   async componentWillLoad(): Promise<void> {
-    listenTo('cl.cart.hostedCartUpdate', (event) => {
+    listenTo('cl-cart-hostedcartupdate', (event) => {
       const [iframeId] = event.detail.request.args
       if (this.iframe.id !== iframeId) {
         this.flag_listenForHostedCartUpdateResponse = false
@@ -98,7 +98,7 @@ export class ClCart {
       }
     })
 
-    listenTo('cl.cart.update', async () => {
+    listenTo('cl-cart-update', async () => {
       this.flag_justAddedToCart = true
       this.iframe.iFrameResizer.sendMessage(hostedCartIframeUpdateEvent)
 

--- a/packages/drop-in/src/components/cl-checkout-link/cl-checkout-link.tsx
+++ b/packages/drop-in/src/components/cl-checkout-link/cl-checkout-link.tsx
@@ -18,7 +18,7 @@ export class ClCheckoutLink implements Props {
   @State() href: string | undefined
 
   async componentWillLoad(): Promise<void> {
-    listenTo('cl.cart.update', async (event) => {
+    listenTo('cl-cart-update', async (event) => {
       if (
         this.href === undefined &&
         event.detail.response.skus_count !== undefined &&
@@ -28,7 +28,7 @@ export class ClCheckoutLink implements Props {
       }
     })
 
-    listenTo('cl.cart.hostedCartUpdate', (event) => {
+    listenTo('cl-cart-hostedcartupdate', (event) => {
       if (
         event.detail.response.skus_count === undefined ||
         event.detail.response.skus_count === 0

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -27,9 +27,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <!-- <script>
-      document.addEventListener('cl.skus.getSku', (e) => console.info('skus.getSku', e.detail))
-      document.addEventListener('cl.prices.getPrice', (e) => console.info('prices.getPrice', e.detail))
-      document.addEventListener('cl.cart.addItem', (e) => console.info('cart.addItem', e.detail))
+      document.addEventListener('cl-skus-getsku', (e) => console.info('skus.getSku', e.detail))
+      document.addEventListener('cl-prices-getprice', (e) => console.info('prices.getPrice', e.detail))
+      document.addEventListener('cl-cart-additem', (e) => console.info('cart.addItem', e.detail))
     </script> -->
 
     <script>

--- a/packages/drop-in/src/utils/debounce.spec.ts
+++ b/packages/drop-in/src/utils/debounce.spec.ts
@@ -1,0 +1,50 @@
+import { memoDebounce } from './debounce'
+
+describe('debounce', () => {
+  describe('memoDebounce', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should debounce the function given the same list of arguments (expect 1 dispatch)', () => {
+      const fn = jest.fn()
+      const dfn = memoDebounce(fn, 10, { leading: true, trailing: false })
+      setTimeout(() => dfn(1, 'a', {}), 0)
+      setTimeout(() => dfn(1, 'a', {}), 8)
+      setTimeout(() => dfn(1, 'a', {}), 18)
+      setTimeout(() => dfn(1, 'a', {}), 25)
+      jest.advanceTimersByTime(50)
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should debounce the function given the same list of arguments (expect 2 dispatches)', () => {
+      const fn = jest.fn()
+      const dfn = memoDebounce(fn, 10, { leading: true, trailing: false })
+      setTimeout(() => dfn(), 0)
+      setTimeout(() => dfn(), 8)
+      setTimeout(() => dfn(), 19) // 11ms after
+      setTimeout(() => dfn(), 25)
+      jest.advanceTimersByTime(50)
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should debounce the function given a list of different arguments', () => {
+      const fn = jest.fn()
+      const dfn = memoDebounce(fn, 10, { leading: true, trailing: false })
+      setTimeout(() => dfn('arg1'), 0)
+      setTimeout(() => dfn('arg1'), 10)
+      setTimeout(() => dfn('something else'), 1)
+      setTimeout(() => dfn('arg1', 'arg2'), 3)
+      setTimeout(() => dfn('arg1', { name: 'M' }), 3)
+      setTimeout(() => dfn('arg1', { name: 'M' }), 10)
+      setTimeout(() => dfn('arg1', { name: 'L' }), 3)
+      setTimeout(() => dfn('arg1', { name: 'L' }), 10)
+      jest.advanceTimersByTime(30)
+      expect(fn).toHaveBeenCalledTimes(5)
+    })
+  })
+})

--- a/packages/drop-in/src/utils/debounce.ts
+++ b/packages/drop-in/src/utils/debounce.ts
@@ -42,6 +42,18 @@ export const pDebounce = <T extends (arg: any[]) => any>(
   }
 }
 
+/**
+ * Creates a memoized-debounced function that delays invoking `func` until after `wait` milliseconds
+ * have elapsed since the last time the memoized-debounced function was invoked.
+ *
+ * The function is also **memoized** using all arguments as the map cache key. You can override this
+ * default by providing a `resolver` function.
+ * @param func The function to debounce.
+ * @param wait The number of milliseconds to delay.
+ * @param options The options object.
+ * @param resolver The function to resolve the cache key (for memoized function).
+ * @returns Returns the new memoized function debounced.
+ */
 export function memoDebounce<F extends (...args: any[]) => any>(
   func: F,
   wait = 0,


### PR DESCRIPTION
Rename event names to follow a more widely used naming convention:
- `cl.prices.getPrice` → `cl-prices-getprice`
- `cl.skus.getSku` → `cl-skus-getsku`
- `cl.cart.addItem` → `cl-cart-additem`