### PR TITLE
Update `cart_url` only when different

### DIFF
--- a/packages/drop-in/src/apis/commercelayer/cart.ts
+++ b/packages/drop-in/src/apis/commercelayer/cart.ts
@@ -192,7 +192,7 @@ export const addItem: AddItem = async (sku, quantity) => {
 export async function updateCartUrl(cartUrl: string): Promise<void> {
   const cart = await getCart()
 
-  if (cart !== null) {
+  if (cart !== null && cart.cart_url !== cartUrl) {
     const client = await createClient(getConfig())
     await client.orders.update({
       id: cart.id,


### PR DESCRIPTION
### What does this PR do?

This PR will let the drop-in updates the order `cart_url` only if the value is different from the one the order already has.

### What are the relevant issues this PR belongs to

- resolves #29 
