### PR TITLE
Rename `returnUrl` to `orderReturnUrl`

### DIFF
--- a/packages/docs/stories/getting-started.mdx
+++ b/packages/docs/stories/getting-started.mdx
@@ -10,13 +10,13 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
 1. Import the library from the [CDN](https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@1.4.0/dist/drop-in/drop-in.esm.js).
 2. Declare a global variable called `commercelayerConfig` and set the following attributes.
 
-| Attribute       | Type   | Required | Description                                                                                                                                                                                                      |
-|-----------------|--------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **`clientId`**  | String |     ✓    | Your [sales channel](https://docs.commercelayer.io/core/applications#sales-channel) client ID. You can find it in your application details page on your dashboard.                                                                                                                | 
-| **`slug`**      | String |     ✓    | Your organization slug (i.e. the subdomain of your base endpoint, usually the slugified version of your organization's name). You can find the base endpoint in your application details page on your dashboard. |
-| **`scope`**     | String |     ✓    | Your sales channel [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) (use it to restrict the dataset of your application). You can find the allowed scopes in your application details page on your dashboard.                                                |
-| `debug`         | String |          | The debug level. Can be one of `none` or `all`. Default is `none`.                                                                                                                                               |
-| `returnUrl`     | String |          | The URL the cart's *Continue shopping* button points to. This is also used in the thank you page.                                                                                                           |
+| Attribute            | Type   | Required | Description                                                                                                                                                                                                      |
+|----------------------|--------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`clientId`**       | String |     ✓    | Your [sales channel](https://docs.commercelayer.io/core/applications#sales-channel) client ID. You can find it in your application details page on your dashboard.                                                                                                                | 
+| **`slug`**           | String |     ✓    | Your organization slug (i.e. the subdomain of your base endpoint, usually the slugified version of your organization's name). You can find the base endpoint in your application details page on your dashboard. |
+| **`scope`**          | String |     ✓    | Your sales channel [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) (use it to restrict the dataset of your application). You can find the allowed scopes in your application details page on your dashboard.                                                |
+| `debug`              | String |          | The debug level. Can be one of `none` or `all`. Default is `none`.                                                                                                                                               |
+| `orderReturnUrl`     | String |          | The URL the cart's *Continue shopping* button points to. This is also used in the thank you page.                                                                                                           |
 
 
  The final result should be similar to the code snippet below:
@@ -31,7 +31,7 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
       slug: 'drop-in-js',
       scope: 'market:11709',
       debug: 'all', // default is 'none'
-      returnUrl: 'https://example.com' // optional
+      orderReturnUrl: 'https://example.com' // optional
     }
   }());
 </script>

--- a/packages/drop-in/src/apis/commercelayer/cart.ts
+++ b/packages/drop-in/src/apis/commercelayer/cart.ts
@@ -21,7 +21,7 @@ async function createEmptyCart(): Promise<Order> {
   const config = getConfig()
   const client = await createClient(config)
   const order = await client.orders.create({
-    return_url: config.returnUrl
+    return_url: config.orderReturnUrl
   })
 
   setCartId(order.id)

--- a/packages/drop-in/src/apis/commercelayer/config.ts
+++ b/packages/drop-in/src/apis/commercelayer/config.ts
@@ -28,7 +28,7 @@ export interface CommerceLayerConfig {
   /**
    * Url used in the Hosted Cart to point to "Continue Shopping". This is also used in the thank you page.
    */
-  returnUrl?: string
+  orderReturnUrl?: string
 
   /**
    * API domain
@@ -80,11 +80,11 @@ export function getConfig(): Config {
   }
 
   if (
-    commercelayerConfig.returnUrl !== undefined &&
-    typeof commercelayerConfig.returnUrl !== 'string'
+    commercelayerConfig.orderReturnUrl !== undefined &&
+    typeof commercelayerConfig.orderReturnUrl !== 'string'
   ) {
     throw new Error(
-      `"window.commercelayerConfig.returnUrl" is set but not a string.\n${documentationLink}\n`
+      `"window.commercelayerConfig.orderReturnUrl" is set but not a string.\n${documentationLink}\n`
     )
   }
 

--- a/packages/drop-in/src/cart.html
+++ b/packages/drop-in/src/cart.html
@@ -39,7 +39,7 @@
           slug: 'drop-in-js',
           scope: 'market:11709',
           debug: 'all',
-          returnUrl: 'https://example.com'
+          orderReturnUrl: 'https://example.com'
         }
       }());
     </script>

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -44,7 +44,7 @@
                     slug: 'drop-in-js-stg',
                     scope: 'market:545',
                     debug: 'all',
-                    returnUrl: 'https://example.com'
+                    orderReturnUrl: 'https://example.com'
                     // validScopes: ['market:545', 'market:1234', ''],
                 };
 
@@ -54,7 +54,7 @@
                 //   slug: 'drop-in-js',
                 //   scope: 'market:11709',
                 //   debug: 'all',
-                //   returnUrl: 'https://example.com'
+                //   orderReturnUrl: 'https://example.com'
                 // }
             })();
         </script>

--- a/packages/drop-in/src/utils/logger.spec.ts
+++ b/packages/drop-in/src/utils/logger.spec.ts
@@ -6,7 +6,7 @@ function injectConfig({
   slug = 'example',
   scope = 'market:123',
   debug,
-  returnUrl
+  orderReturnUrl
 }: Partial<Config>): void {
   Object.defineProperty(window, 'commercelayerConfig', {
     value: {
@@ -14,7 +14,7 @@ function injectConfig({
       slug,
       scope,
       debug,
-      returnUrl
+      orderReturnUrl
     }
   })
 }


### PR DESCRIPTION
`returnUrl` was too generic:

```diff
  window.commercelayerConfig = {
      clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
      slug: 'drop-in-js',
      scope: 'market:11709',
      debug: 'all',
-    returnUrl: 'https://example.com'
+    orderReturnUrl: 'https://example.com'
  }
```