### PR TITLE
Empty fields when there are no results

### DIFF
--- a/packages/drop-in/src/components/cl-availability-info/cl-availability-info.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability-info/cl-availability-info.spec.tsx
@@ -210,4 +210,124 @@ describe('cl-availability-info.spec', () => {
       </div>
     `)
   })
+
+  it('renders as empty when the SKU is undefined', async () => {
+    const { body, waitForChanges } = await newSpecPage({
+      components: [ClAvailabilityInfo],
+      html: `
+        <div>
+          <cl-availability-info type="min-days"></cl-availability-info>
+          <cl-availability-info type="max-days"></cl-availability-info>
+          <cl-availability-info type="min-hours"></cl-availability-info>
+          <cl-availability-info type="max-hours"></cl-availability-info>
+          <cl-availability-info type="shipping-method-name"></cl-availability-info>
+          <cl-availability-info type="shipping-method-price"></cl-availability-info>
+        </div>
+      `
+    })
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-info type="min-days">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-days">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="min-hours">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-hours">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-name">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-price">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+      </div>
+    `)
+
+    const availabilityUpdateEvent: Sku = {
+      id: 'ABC123',
+      code: 'ABC123',
+      name: 'ABC123',
+      type: 'skus',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      inventory: {
+        available: true,
+        quantity: 98,
+        levels: [
+          {
+            delivery_lead_times: [
+              {
+                min: {
+                  days: 1,
+                  hours: 1 * 24
+                },
+                max: {
+                  days: 2,
+                  hours: 2 * 24
+                },
+                shipping_method: {
+                  name: 'Standard',
+                  reference: 'reference-1',
+                  price_amount_cents: 700,
+                  formatted_price_amount: '$7.00',
+                  formatted_free_over_amount: null,
+                  free_over_amount_cents: null
+                }
+              }
+            ],
+            quantity: 98
+          }
+        ]
+      }
+    }
+
+    body.querySelectorAll('cl-availability-info').forEach((element) =>
+      element.dispatchEvent(
+        new CustomEvent<Sku>('availabilityUpdate', {
+          detail: availabilityUpdateEvent
+        })
+      )
+    )
+
+    await waitForChanges()
+
+    body.querySelectorAll('cl-availability-info').forEach((element) =>
+      element.dispatchEvent(
+        new CustomEvent<Sku>('availabilityUpdate', {
+          detail: undefined
+        })
+      )
+    )
+
+    await waitForChanges()
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-info type="min-days">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-days">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="min-hours">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-hours">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-name">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-price">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+      </div>
+    `)
+  })
 })

--- a/packages/drop-in/src/components/cl-availability-info/cl-availability-info.tsx
+++ b/packages/drop-in/src/components/cl-availability-info/cl-availability-info.tsx
@@ -46,13 +46,13 @@ export class ClAvailabilityInfo {
   @State() text: string | undefined
 
   @Listen('availabilityUpdate')
-  availabilityUpdateHandler(event: CustomEvent<Sku>): void {
+  availabilityUpdateHandler(event: CustomEvent<Sku | undefined>): void {
     if (this.type === undefined) {
       return
     }
 
     const deliveryLeadTime =
-      event.detail.inventory?.levels[0]?.delivery_lead_times[0]
+      event.detail?.inventory?.levels[0]?.delivery_lead_times[0]
 
     switch (this.type) {
       case 'min-days':

--- a/packages/drop-in/src/components/cl-availability-status/cl-availability-status.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability-status/cl-availability-status.spec.tsx
@@ -151,4 +151,80 @@ describe('cl-availability-status.spec', () => {
       </div>
     `)
   })
+
+  it('renders as empty when the SKU is undefined', async () => {
+    const { body, waitForChanges } = await newSpecPage({
+      components: [ClAvailabilityStatus],
+      html: `
+        <div>
+          <cl-availability-status type="available">
+            • available
+          </cl-availability-status>
+          <cl-availability-status type="unavailable">
+            • out of stock
+          </cl-availability-status>
+        </div>
+      `
+    })
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-status type="available" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available
+        </cl-availability-status>
+        <cl-availability-status type="unavailable" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • out of stock
+        </cl-availability-status>
+      </div>
+    `)
+
+    const availabilityUpdateEvent: Sku = {
+      id: 'ABC123',
+      code: 'ABC123',
+      name: 'ABC123',
+      type: 'skus',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      inventory: {
+        available: true,
+        quantity: 98,
+        levels: []
+      }
+    }
+
+    body.querySelectorAll('cl-availability-status').forEach((element) =>
+      element.dispatchEvent(
+        new CustomEvent<Sku>('availabilityUpdate', {
+          detail: availabilityUpdateEvent
+        })
+      )
+    )
+
+    await waitForChanges()
+
+    body.querySelectorAll('cl-availability-status').forEach((element) =>
+      element.dispatchEvent(
+        new CustomEvent<Sku>('availabilityUpdate', {
+          detail: undefined
+        })
+      )
+    )
+
+    await waitForChanges()
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-status aria-disabled="true" type="available">
+          <mock:shadow-root></mock:shadow-root>
+          • available
+        </cl-availability-status>
+        <cl-availability-status type="unavailable" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • out of stock
+        </cl-availability-status>
+      </div>
+    `)
+  })
 })

--- a/packages/drop-in/src/components/cl-availability-status/cl-availability-status.tsx
+++ b/packages/drop-in/src/components/cl-availability-status/cl-availability-status.tsx
@@ -33,8 +33,8 @@ export class ClAvailabilityStatus {
   @State() available: boolean | undefined
 
   @Listen('availabilityUpdate')
-  availabilityUpdateHandler(event: CustomEvent<Sku>): void {
-    this.available = event.detail.inventory?.available
+  availabilityUpdateHandler(event: CustomEvent<Sku | undefined>): void {
+    this.available = event.detail?.inventory?.available
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/drop-in/src/components/cl-availability/cl-availability.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability/cl-availability.spec.tsx
@@ -156,4 +156,48 @@ describe('cl-availability.spec', () => {
     </cl-availability>
     `)
   })
+
+  it('should empty the text when the there are no results', async () => {
+    jest
+      .spyOn(skus, 'getSku')
+      .mockImplementation(
+        async (sku: string) => await Promise.resolve(skuList[sku])
+      )
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [ClAvailability, ClAvailabilityStatus],
+      html: `
+        <cl-availability code="AVAILABLE123">
+          <cl-availability-status></cl-availability-status>
+          <cl-availability-status type="available">• available</cl-availability-status>
+          <cl-availability-status type="unavailable">• out of stock</cl-availability-status>
+          <another-tag></another-tag>
+        </cl-availability>
+      `
+    })
+
+    root?.setAttribute('code', 'NONEXISTING')
+
+    await waitForChanges()
+
+    expect(root).toEqualHtml(`
+      <cl-availability code="NONEXISTING">
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+        <cl-availability-status aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-status>
+        <cl-availability-status type="available" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available
+        </cl-availability-status>
+        <cl-availability-status type="unavailable" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • out of stock
+        </cl-availability-status>
+        <another-tag></another-tag>
+    </cl-availability>
+    `)
+  })
 })

--- a/packages/drop-in/src/components/cl-availability/cl-availability.tsx
+++ b/packages/drop-in/src/components/cl-availability/cl-availability.tsx
@@ -30,15 +30,13 @@ export class ClAvailability {
     if (isValidCode(code)) {
       const sku = await getSku(code)
 
-      if (sku !== undefined) {
-        this.host
-          .querySelectorAll('cl-availability-status, cl-availability-info')
-          .forEach((element) => {
-            element.dispatchEvent(
-              new CustomEvent<Sku>('availabilityUpdate', { detail: sku })
-            )
-          })
-      }
+      this.host
+        .querySelectorAll('cl-availability-status, cl-availability-info')
+        .forEach((element) => {
+          element.dispatchEvent(
+            new CustomEvent<Sku>('availabilityUpdate', { detail: sku })
+          )
+        })
     }
   }
 

--- a/packages/drop-in/src/components/cl-price-amount/cl-price-amount.spec.tsx
+++ b/packages/drop-in/src/components/cl-price-amount/cl-price-amount.spec.tsx
@@ -16,35 +16,6 @@ describe('cl-price-amount.spec', () => {
     `)
   })
 
-  it('renders as empty when the Price is undefined', async () => {
-    const { root, waitForChanges } = await newSpecPage({
-      components: [CLPriceAmount],
-      html: '<cl-price-amount type="price"></cl-price-amount>'
-    })
-
-    expect(root).toEqualHtml(`
-      <cl-price-amount type="price">
-        <mock:shadow-root></mock:shadow-root>
-      </cl-price-amount>
-    `)
-
-    const priceUpdateEvent: Price | undefined = undefined
-
-    root?.dispatchEvent(
-      new CustomEvent<Price>('priceUpdate', {
-        detail: priceUpdateEvent
-      })
-    )
-
-    await waitForChanges()
-
-    expect(root).toEqualHtml(`
-      <cl-price-amount type="price">
-        <mock:shadow-root></mock:shadow-root>
-      </cl-price-amount>
-    `)
-  })
-
   it('renders as formatted_amount when `type="price"`', async () => {
     const { root, waitForChanges } = await newSpecPage({
       components: [CLPriceAmount],
@@ -164,6 +135,54 @@ describe('cl-price-amount.spec', () => {
 
     expect(root).toEqualHtml(`
       <cl-price-amount type="compare-at">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-price-amount>
+    `)
+  })
+
+  it('renders as empty when the Price is undefined', async () => {
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CLPriceAmount],
+      html: '<cl-price-amount type="price"></cl-price-amount>'
+    })
+
+    expect(root).toEqualHtml(`
+      <cl-price-amount type="price">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-price-amount>
+    `)
+
+    const priceUpdateEvent: Price = {
+      id: 'ABC123',
+      type: 'prices',
+      amount_cents: 1200,
+      amount_float: 12,
+      compare_at_amount_cents: 2850,
+      compare_at_amount_float: 28.5,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      formatted_amount: '€ 12.00',
+      formatted_compare_at_amount: '€ 28.50'
+    }
+
+    root?.dispatchEvent(
+      new CustomEvent<Price>('priceUpdate', {
+        detail: priceUpdateEvent
+      })
+    )
+
+    await waitForChanges()
+
+    root?.dispatchEvent(
+      new CustomEvent<Price>('priceUpdate', {
+        detail: undefined
+      })
+    )
+
+    await waitForChanges()
+
+    expect(root).toEqualHtml(`
+      <cl-price-amount type="price">
         <mock:shadow-root></mock:shadow-root>
       </cl-price-amount>
     `)

--- a/packages/drop-in/src/components/cl-price-amount/cl-price-amount.spec.tsx
+++ b/packages/drop-in/src/components/cl-price-amount/cl-price-amount.spec.tsx
@@ -16,6 +16,35 @@ describe('cl-price-amount.spec', () => {
     `)
   })
 
+  it('renders as empty when the Price is undefined', async () => {
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CLPriceAmount],
+      html: '<cl-price-amount type="price"></cl-price-amount>'
+    })
+
+    expect(root).toEqualHtml(`
+      <cl-price-amount type="price">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-price-amount>
+    `)
+
+    const priceUpdateEvent: Price | undefined = undefined
+
+    root?.dispatchEvent(
+      new CustomEvent<Price>('priceUpdate', {
+        detail: priceUpdateEvent
+      })
+    )
+
+    await waitForChanges()
+
+    expect(root).toEqualHtml(`
+      <cl-price-amount type="price">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-price-amount>
+    `)
+  })
+
   it('renders as formatted_amount when `type="price"`', async () => {
     const { root, waitForChanges } = await newSpecPage({
       components: [CLPriceAmount],

--- a/packages/drop-in/src/components/cl-price-amount/cl-price-amount.tsx
+++ b/packages/drop-in/src/components/cl-price-amount/cl-price-amount.tsx
@@ -22,7 +22,7 @@ export class CLPriceAmount {
   @State() price: Price | undefined
 
   @Listen('priceUpdate')
-  priceUpdateHandler(event: CustomEvent<Price>): void {
+  priceUpdateHandler(event: CustomEvent<Price | undefined>): void {
     this.price = event.detail
   }
 

--- a/packages/drop-in/src/components/cl-price/cl-price.spec.tsx
+++ b/packages/drop-in/src/components/cl-price/cl-price.spec.tsx
@@ -120,4 +120,38 @@ describe('cl-price.spec', () => {
     </cl-price>
     `)
   })
+
+  it('should empty the price when the there are no results', async () => {
+    jest
+      .spyOn(prices, 'getPrice')
+      .mockImplementation(
+        async (sku: string) => await Promise.resolve(fakePrices[sku])
+      )
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CLPrice, CLPriceAmount],
+      html: `
+        <cl-price code="ABC123">
+          <cl-price-amount></cl-price-amount>
+          <another-tag></another-tag>
+        </cl-price>
+      `
+    })
+
+    root?.setAttribute('code', 'ABC456')
+
+    await waitForChanges()
+
+    expect(root).toEqualHtml(`
+      <cl-price code="ABC456">
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+        <cl-price-amount type="price">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-price-amount>
+        <another-tag></another-tag>
+    </cl-price>
+    `)
+  })
 })

--- a/packages/drop-in/src/components/cl-price/cl-price.tsx
+++ b/packages/drop-in/src/components/cl-price/cl-price.tsx
@@ -30,13 +30,11 @@ export class CLPrice {
     if (isValidCode(code)) {
       const price = await getPrice(code)
 
-      if (price !== undefined) {
-        this.host.querySelectorAll('cl-price-amount').forEach((element) => {
-          element.dispatchEvent(
-            new CustomEvent<Price>('priceUpdate', { detail: price })
-          )
-        })
-      }
+      this.host.querySelectorAll('cl-price-amount').forEach((element) => {
+        element.dispatchEvent(
+          new CustomEvent<Price>('priceUpdate', { detail: price })
+        )
+      })
     }
   }
 

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -128,6 +128,7 @@
                                     <option value="BACKPACKFFFFFF000000XXXX">No Discount</option>
                                     <option value="5PANECAP9D9CA1FFFFFFXXXX">Out Of Stock</option>
                                     <option value="GMUG11OZFFFFFF000000XXXX">Overselling</option>
+                                    <option value="SKU5678">Non-Existing SKU</option>
                                 </select>
                             </code>
                         </div>


### PR DESCRIPTION
Closes #48

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When changing the `code`, if there are no results we should empty the field.
For example when changing the code on a `cl-price` if there are no results we are showing the old price.

This PR aims to solve this issue.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
