### PR TITLE
Add `rule` prop to the `cl-availability` component

### DIFF
--- a/packages/docs/.storybook/addon-scope-selector/constants.ts
+++ b/packages/docs/.storybook/addon-scope-selector/constants.ts
@@ -1,4 +1,4 @@
-export const DESCRIPTION = 'Select an authorization scope.'
+export const DESCRIPTION = 'Toggle this switch to change the market in scope.'
 export const ADDON_ID = 'addon-scope-selector' as const
 export const ADDON_TITLE = DESCRIPTION
 export const TOOL_ID = `${ADDON_ID}/tool` as const

--- a/packages/docs/stories/availability/cl-availability.mdx
+++ b/packages/docs/stories/availability/cl-availability.mdx
@@ -11,10 +11,6 @@ Once you have correctly set up your organization in Commerce Layer and imported 
 
 This component is the owner of the availability information. It fetches the inventory of the specified SKU and dispatches it to the [`cl-availability-status`](?path=/docs/components-availability-cl-availability-status--docs) and [`cl-availability-info`](?path=/docs/components-availability-cl-availability-info--docs) children.
 
-<Alert title="Multiple delivery lead times" type="warning">
-  Please note that, if different delivery lead times are available, only the one associated with the lower shipping method cost is displayed.
-</Alert>
-
 <Canvas of={Stories.Basic} />
 
 <Controls of={Stories.Basic} />

--- a/packages/docs/stories/availability/cl-availability.stories.ts
+++ b/packages/docs/stories/availability/cl-availability.stories.ts
@@ -16,14 +16,14 @@ export default meta
 const Template: StoryFn<Args> = (args) => {
   return create(
     html`
-      <cl-availability code=${args.code ?? nothing}>
+      <cl-availability code=${args.code ?? nothing} rule=${args.rule ?? nothing}>
         <cl-availability-status type="available">
           <span style="color: green;">• available</span>
           ready to be shipped in
           <cl-availability-info type="min-days"></cl-availability-info
           // eslint-disable-next-line prettier/prettier
-          >-<cl-availability-info type="max-days"></cl-availability-info>
-          days
+          >-<cl-availability-info type="max-days"></cl-availability-info> days
+          with <cl-availability-info type="shipping-method-name"></cl-availability-info> (<cl-availability-info type="shipping-method-price"></cl-availability-info>)
         </cl-availability-status>
         <cl-availability-status type="unavailable" style="color: red;">
           • out of stock

--- a/packages/docs/stories/introduction.mdx
+++ b/packages/docs/stories/introduction.mdx
@@ -46,7 +46,7 @@ Prices, availability messages, shopping cart, and more are automatically mixed i
 
 ## Demo 🚀
 
-If you want to see most of the reusable components above in action before digging into the details, check this simple product landing page. Feel free to take a look at the code by clicking on the *Show code* button to see how straightforward it is. Toggle the related switch in the header to activate/deactivate the components [styling](?path=/docs/getting-started--docs#styling) (we are using [Tailwind](https://tailwindcss.com/) to speed up the layout building).
+If you want to see most of the reusable components above in action before digging into the details, check this simple product landing page. Feel free to take a look at the code by clicking on the *Show code* button to see how straightforward it is. Toggle the related switches in the header to activate/deactivate the components [styling](?path=/docs/getting-started--docs#styling) (we are using [Tailwind](https://tailwindcss.com/) to speed up the layout building) and/or to select your API calls scope in terms of available markets.
 
 We've called it a demo, but the truth is that by switching the linked organization [from test to live mode](https://docs.commercelayer.io/core/api-specification#environments) on the Commerce Layer Admin Dashboard, this can be considered a full-fledged, up and running production website 😮 — and it took a snap to build it!
 

--- a/packages/drop-in/src/apis/types.ts
+++ b/packages/drop-in/src/apis/types.ts
@@ -50,3 +50,10 @@ export type TriggerHostedCartUpdate = (
 ) => Promise<Order | null>
 
 export type TriggerCartUpdate = () => Promise<Order | null>
+
+// Event types
+
+export interface AvailabilityUpdateEventPayload {
+  sku: Sku | undefined
+  rule: 'cheapest' | 'fastest'
+}

--- a/packages/drop-in/src/components.d.ts
+++ b/packages/drop-in/src/components.d.ts
@@ -21,6 +21,10 @@ export namespace Components {
           * The SKU code (i.e. the unique identifier of the product whose availability you want to display).
          */
         "code": string | undefined;
+        /**
+          * The rule used to determine the information that will be displayed. `cheapest` is the delivery lead time associated with the lower shipping method cost, `fastest` is the delivery lead time associated with the lower average time to delivery.
+         */
+        "rule": 'cheapest' | 'fastest';
     }
     interface ClAvailabilityInfo {
         /**
@@ -218,6 +222,10 @@ declare namespace LocalJSX {
           * The SKU code (i.e. the unique identifier of the product whose availability you want to display).
          */
         "code": string | undefined;
+        /**
+          * The rule used to determine the information that will be displayed. `cheapest` is the delivery lead time associated with the lower shipping method cost, `fastest` is the delivery lead time associated with the lower average time to delivery.
+         */
+        "rule"?: 'cheapest' | 'fastest';
     }
     interface ClAvailabilityInfo {
         /**

--- a/packages/drop-in/src/components/cl-availability-info/cl-availability-info.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability-info/cl-availability-info.spec.tsx
@@ -1,4 +1,4 @@
-import type { Sku } from '#apis/types'
+import type { AvailabilityUpdateEventPayload, Sku } from '#apis/types'
 import { newSpecPage } from '@stencil/core/testing'
 import { ClAvailabilityInfo } from './cl-availability-info'
 
@@ -15,7 +15,7 @@ describe('cl-availability-info.spec', () => {
     `)
   })
 
-  it('renders the availability message when the product is available', async () => {
+  it('renders the availability message when the product is available (cheapest as default)', async () => {
     const { body, waitForChanges } = await newSpecPage({
       components: [ClAvailabilityInfo],
       html: `
@@ -53,7 +53,7 @@ describe('cl-availability-info.spec', () => {
       </div>
     `)
 
-    const availabilityUpdateEvent: Sku = {
+    const sku: Sku = {
       id: 'ABC123',
       code: 'ABC123',
       name: 'ABC123',
@@ -68,18 +68,36 @@ describe('cl-availability-info.spec', () => {
             delivery_lead_times: [
               {
                 min: {
-                  days: 1,
-                  hours: 1 * 24
+                  days: 5,
+                  hours: 5 * 24
                 },
                 max: {
-                  days: 2,
-                  hours: 2 * 24
+                  days: 10,
+                  hours: 10 * 24
                 },
                 shipping_method: {
                   name: 'Standard',
                   reference: 'reference-1',
                   price_amount_cents: 700,
                   formatted_price_amount: '$7.00',
+                  formatted_free_over_amount: null,
+                  free_over_amount_cents: null
+                }
+              },
+              {
+                min: {
+                  days: 6,
+                  hours: 6 * 24
+                },
+                max: {
+                  days: 7,
+                  hours: 7 * 24
+                },
+                shipping_method: {
+                  name: 'Express',
+                  reference: 'reference-2',
+                  price_amount_cents: 2000,
+                  formatted_price_amount: '$20.00',
                   formatted_free_over_amount: null,
                   free_over_amount_cents: null
                 }
@@ -93,8 +111,11 @@ describe('cl-availability-info.spec', () => {
 
     body.querySelectorAll('cl-availability-info').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: availabilityUpdateEvent
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
         })
       )
     )
@@ -104,22 +125,153 @@ describe('cl-availability-info.spec', () => {
     expect(body).toEqualHtml(`
       <div>
         <cl-availability-info type="min-days">
-          <mock:shadow-root>1</mock:shadow-root>
+          <mock:shadow-root>5</mock:shadow-root>
         </cl-availability-info>
         <cl-availability-info type="max-days">
-          <mock:shadow-root>2</mock:shadow-root>
+          <mock:shadow-root>10</mock:shadow-root>
         </cl-availability-info>
         <cl-availability-info type="min-hours">
-          <mock:shadow-root>24</mock:shadow-root>
+          <mock:shadow-root>120</mock:shadow-root>
         </cl-availability-info>
         <cl-availability-info type="max-hours">
-          <mock:shadow-root>48</mock:shadow-root>
+          <mock:shadow-root>240</mock:shadow-root>
         </cl-availability-info>
         <cl-availability-info type="shipping-method-name">
           <mock:shadow-root>Standard</mock:shadow-root>
         </cl-availability-info>
         <cl-availability-info type="shipping-method-price">
           <mock:shadow-root>$7.00</mock:shadow-root>
+        </cl-availability-info>
+      </div>
+    `)
+  })
+
+  it('renders the availability message when the product is available (fastest)', async () => {
+    const { body, waitForChanges } = await newSpecPage({
+      components: [ClAvailabilityInfo],
+      html: `
+        <div>
+          <cl-availability-info type="min-days"></cl-availability-info>
+          <cl-availability-info type="max-days"></cl-availability-info>
+          <cl-availability-info type="min-hours"></cl-availability-info>
+          <cl-availability-info type="max-hours"></cl-availability-info>
+          <cl-availability-info type="shipping-method-name"></cl-availability-info>
+          <cl-availability-info type="shipping-method-price"></cl-availability-info>
+        </div>
+      `
+    })
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-info type="min-days">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-days">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="min-hours">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-hours">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-name">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-price">
+          <mock:shadow-root></mock:shadow-root>
+        </cl-availability-info>
+      </div>
+    `)
+
+    const sku: Sku = {
+      id: 'ABC123',
+      code: 'ABC123',
+      name: 'ABC123',
+      type: 'skus',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      inventory: {
+        available: true,
+        quantity: 98,
+        levels: [
+          {
+            delivery_lead_times: [
+              {
+                min: {
+                  days: 5,
+                  hours: 5 * 24
+                },
+                max: {
+                  days: 10,
+                  hours: 10 * 24
+                },
+                shipping_method: {
+                  name: 'Standard',
+                  reference: 'reference-1',
+                  price_amount_cents: 700,
+                  formatted_price_amount: '$7.00',
+                  formatted_free_over_amount: null,
+                  free_over_amount_cents: null
+                }
+              },
+              {
+                min: {
+                  days: 6,
+                  hours: 6 * 24
+                },
+                max: {
+                  days: 7,
+                  hours: 7 * 24
+                },
+                shipping_method: {
+                  name: 'Express',
+                  reference: 'reference-2',
+                  price_amount_cents: 2000,
+                  formatted_price_amount: '$20.00',
+                  formatted_free_over_amount: null,
+                  free_over_amount_cents: null
+                }
+              }
+            ],
+            quantity: 98
+          }
+        ]
+      }
+    }
+
+    body.querySelectorAll('cl-availability-info').forEach((element) =>
+      element.dispatchEvent(
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'fastest'
+          }
+        })
+      )
+    )
+
+    await waitForChanges()
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-info type="min-days">
+          <mock:shadow-root>6</mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-days">
+          <mock:shadow-root>7</mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="min-hours">
+          <mock:shadow-root>144</mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-hours">
+          <mock:shadow-root>168</mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-name">
+          <mock:shadow-root>Express</mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="shipping-method-price">
+          <mock:shadow-root>$20.00</mock:shadow-root>
         </cl-availability-info>
       </div>
     `)
@@ -163,7 +315,7 @@ describe('cl-availability-info.spec', () => {
       </div>
     `)
 
-    const availabilityUpdateEvent: Sku = {
+    const sku: Sku = {
       id: 'ABC123',
       code: 'ABC123',
       name: 'ABC123',
@@ -179,8 +331,11 @@ describe('cl-availability-info.spec', () => {
 
     body.querySelectorAll('cl-availability-info').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: availabilityUpdateEvent
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
         })
       )
     )
@@ -249,7 +404,7 @@ describe('cl-availability-info.spec', () => {
       </div>
     `)
 
-    const availabilityUpdateEvent: Sku = {
+    const sku: Sku = {
       id: 'ABC123',
       code: 'ABC123',
       name: 'ABC123',
@@ -289,8 +444,11 @@ describe('cl-availability-info.spec', () => {
 
     body.querySelectorAll('cl-availability-info').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: availabilityUpdateEvent
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
         })
       )
     )
@@ -299,8 +457,11 @@ describe('cl-availability-info.spec', () => {
 
     body.querySelectorAll('cl-availability-info').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: undefined
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku: undefined,
+            rule: 'cheapest'
+          }
         })
       )
     )

--- a/packages/drop-in/src/components/cl-availability-status/cl-availability-status.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability-status/cl-availability-status.spec.tsx
@@ -1,4 +1,4 @@
-import type { Sku } from '#apis/types'
+import type { AvailabilityUpdateEventPayload, Sku } from '#apis/types'
 import { newSpecPage } from '@stencil/core/testing'
 import { ClAvailabilityStatus } from './cl-availability-status'
 
@@ -44,7 +44,7 @@ describe('cl-availability-status.spec', () => {
       </div>
     `)
 
-    const availabilityUpdateEvent: Sku = {
+    const sku: Sku = {
       id: 'ABC123',
       code: 'ABC123',
       name: 'ABC123',
@@ -60,8 +60,11 @@ describe('cl-availability-status.spec', () => {
 
     body.querySelectorAll('cl-availability-status').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: availabilityUpdateEvent
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
         })
       )
     )
@@ -112,7 +115,7 @@ describe('cl-availability-status.spec', () => {
       </div>
     `)
 
-    const availabilityUpdateEvent: Sku = {
+    const sku: Sku = {
       id: 'ABC123',
       code: 'ABC123',
       name: 'ABC123',
@@ -128,8 +131,11 @@ describe('cl-availability-status.spec', () => {
 
     body.querySelectorAll('cl-availability-status').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: availabilityUpdateEvent
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
         })
       )
     )
@@ -180,7 +186,7 @@ describe('cl-availability-status.spec', () => {
       </div>
     `)
 
-    const availabilityUpdateEvent: Sku = {
+    const sku: Sku = {
       id: 'ABC123',
       code: 'ABC123',
       name: 'ABC123',
@@ -196,8 +202,11 @@ describe('cl-availability-status.spec', () => {
 
     body.querySelectorAll('cl-availability-status').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
-          detail: availabilityUpdateEvent
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
         })
       )
     )
@@ -206,7 +215,7 @@ describe('cl-availability-status.spec', () => {
 
     body.querySelectorAll('cl-availability-status').forEach((element) =>
       element.dispatchEvent(
-        new CustomEvent<Sku>('availabilityUpdate', {
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
           detail: undefined
         })
       )

--- a/packages/drop-in/src/components/cl-availability-status/cl-availability-status.tsx
+++ b/packages/drop-in/src/components/cl-availability-status/cl-availability-status.tsx
@@ -1,4 +1,4 @@
-import type { Sku } from '#apis/types'
+import type { AvailabilityUpdateEventPayload } from '#apis/types'
 import { logUnion } from '#utils/validation-helpers'
 import {
   Component,
@@ -33,8 +33,10 @@ export class ClAvailabilityStatus {
   @State() available: boolean | undefined
 
   @Listen('availabilityUpdate')
-  availabilityUpdateHandler(event: CustomEvent<Sku | undefined>): void {
-    this.available = event.detail?.inventory?.available
+  availabilityUpdateHandler(
+    event: CustomEvent<AvailabilityUpdateEventPayload>
+  ): void {
+    this.available = event.detail?.sku?.inventory?.available
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/drop-in/src/components/cl-availability/cl-availability.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability/cl-availability.spec.tsx
@@ -1,6 +1,7 @@
 import * as skus from '#apis/commercelayer/skus'
 import type { Sku } from '#apis/types'
 import { ClAvailabilityStatus } from '#components/cl-availability-status/cl-availability-status'
+import { ClAvailabilityInfo } from '#components/cl-availability-info/cl-availability-info'
 import { newSpecPage } from '@stencil/core/testing'
 import { ClAvailability } from './cl-availability'
 
@@ -19,7 +20,31 @@ const skuList: { [code: string]: Sku } = {
   AVAILABLE123: {
     ...baseSku('AVAILABLE123'),
     inventory: {
-      levels: [],
+      levels: [
+        {
+          delivery_lead_times: [
+            {
+              min: {
+                days: 1,
+                hours: 1 * 24
+              },
+              max: {
+                days: 2,
+                hours: 2 * 24
+              },
+              shipping_method: {
+                name: 'Standard',
+                reference: 'reference-1',
+                price_amount_cents: 700,
+                formatted_price_amount: '$7.00',
+                formatted_free_over_amount: null,
+                free_over_amount_cents: null
+              }
+            }
+          ],
+          quantity: 98
+        }
+      ],
       available: true,
       quantity: 98
     }
@@ -41,7 +66,7 @@ describe('cl-availability.spec', () => {
       html: `<cl-availability></cl-availability>`
     })
     expect(page.root).toEqualHtml(`
-      <cl-availability>
+      <cl-availability rule="cheapest">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -61,7 +86,7 @@ describe('cl-availability.spec', () => {
       html: '<cl-availability code="AVAILABLE123"></cl-availability>'
     })
     expect(root).toEqualHtml(`
-      <cl-availability code="AVAILABLE123">
+      <cl-availability code="AVAILABLE123" rule="cheapest">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -77,19 +102,21 @@ describe('cl-availability.spec', () => {
       )
 
     const { root } = await newSpecPage({
-      components: [ClAvailability, ClAvailabilityStatus],
+      components: [ClAvailability, ClAvailabilityStatus, ClAvailabilityInfo],
       html: `
         <cl-availability code="AVAILABLE123">
           <cl-availability-status></cl-availability-status>
           <cl-availability-status type="available">• available</cl-availability-status>
           <cl-availability-status type="unavailable">• out of stock</cl-availability-status>
+          <cl-availability-info type="min-days"></cl-availability-info>
+          <cl-availability-info type="max-days"></cl-availability-info>
           <another-tag></another-tag>
         </cl-availability>
       `
     })
 
     expect(root).toEqualHtml(`
-      <cl-availability code="AVAILABLE123">
+      <cl-availability code="AVAILABLE123" rule="cheapest">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -106,6 +133,12 @@ describe('cl-availability.spec', () => {
           <mock:shadow-root></mock:shadow-root>
           • out of stock
         </cl-availability-status>
+        <cl-availability-info type="min-days">
+          <mock:shadow-root>1</mock:shadow-root>
+        </cl-availability-info>
+        <cl-availability-info type="max-days">
+          <mock:shadow-root>2</mock:shadow-root>
+        </cl-availability-info>
         <another-tag></another-tag>
     </cl-availability>
     `)
@@ -135,7 +168,7 @@ describe('cl-availability.spec', () => {
     await waitForChanges()
 
     expect(root).toEqualHtml(`
-      <cl-availability code="NOTAVAILABLE456">
+      <cl-availability code="NOTAVAILABLE456" rule="cheapest">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -181,7 +214,7 @@ describe('cl-availability.spec', () => {
     await waitForChanges()
 
     expect(root).toEqualHtml(`
-      <cl-availability code="NONEXISTING">
+      <cl-availability code="NONEXISTING" rule="cheapest">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>

--- a/packages/drop-in/src/components/cl-availability/cl-availability.tsx
+++ b/packages/drop-in/src/components/cl-availability/cl-availability.tsx
@@ -1,5 +1,5 @@
 import { getSku } from '#apis/commercelayer/skus'
-import type { Sku } from '#apis/types'
+import type { AvailabilityUpdateEventPayload } from '#apis/types'
 import { isValidCode, logCode } from '#utils/validation-helpers'
 import { Component, Element, Prop, Watch, h, type JSX } from '@stencil/core'
 
@@ -14,6 +14,13 @@ export class ClAvailability {
    * The SKU code (i.e. the unique identifier of the product whose availability you want to display).
    */
   @Prop({ reflect: true }) code!: string | undefined
+
+  /**
+   * The rule used to determine the information that will be displayed.
+   * `cheapest` is the delivery lead time associated with the lower shipping method cost,
+   * `fastest` is the delivery lead time associated with the lower average time to delivery.
+   */
+  @Prop({ reflect: true }) rule: 'cheapest' | 'fastest' = 'cheapest'
 
   async componentWillLoad(): Promise<void> {
     logCode(this.host, this.code)
@@ -34,7 +41,12 @@ export class ClAvailability {
         .querySelectorAll('cl-availability-status, cl-availability-info')
         .forEach((element) => {
           element.dispatchEvent(
-            new CustomEvent<Sku>('availabilityUpdate', { detail: sku })
+            new CustomEvent<AvailabilityUpdateEventPayload>(
+              'availabilityUpdate',
+              {
+                detail: { sku, rule: this.rule }
+              }
+            )
           )
         })
     }

--- a/packages/drop-in/src/components/cl-availability/readme.md
+++ b/packages/drop-in/src/components/cl-availability/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property            | Attribute | Description                                                                                      | Type                  | Default     |
-| ------------------- | --------- | ------------------------------------------------------------------------------------------------ | --------------------- | ----------- |
-| `code` _(required)_ | `code`    | The SKU code (i.e. the unique identifier of the product whose availability you want to display). | `string \| undefined` | `undefined` |
+| Property            | Attribute | Description                                                                                                                                                                                                                                     | Type                      | Default      |
+| ------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------ |
+| `code` _(required)_ | `code`    | The SKU code (i.e. the unique identifier of the product whose availability you want to display).                                                                                                                                                | `string \| undefined`     | `undefined`  |
+| `rule`              | `rule`    | The rule used to determine the information that will be displayed. `cheapest` is the delivery lead time associated with the lower shipping method cost, `fastest` is the delivery lead time associated with the lower average time to delivery. | `"cheapest" \| "fastest"` | `'cheapest'` |
 
 
 ----------------------------------------------

--- a/packages/drop-in/src/index.e2e.ts
+++ b/packages/drop-in/src/index.e2e.ts
@@ -223,7 +223,7 @@ describe('index.e2e', () => {
             <cl-price-amount type="price" cl-hydrated></cl-price-amount>
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
-          <cl-availability cl-hydrated code="${codes.available}">
+          <cl-availability cl-hydrated code="${codes.available}" rule="cheapest">
             <cl-availability-status cl-hydrated type="available">
               <span style="color: green;">Available</span>
               ready to be shipped in
@@ -244,7 +244,7 @@ describe('index.e2e', () => {
             <cl-price-amount type="price" cl-hydrated></cl-price-amount>
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
-          <cl-availability cl-hydrated code="${codes.noDiscount}">
+          <cl-availability cl-hydrated code="${codes.noDiscount}" rule="cheapest">
             <cl-availability-status cl-hydrated type="available">
               <span style="color: green;">Available</span>
               ready to be shipped in
@@ -265,7 +265,7 @@ describe('index.e2e', () => {
             <cl-price-amount type="price" cl-hydrated></cl-price-amount>
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
-          <cl-availability cl-hydrated code="${codes.outOfStock}">
+          <cl-availability cl-hydrated code="${codes.outOfStock}" rule="cheapest">
             <cl-availability-status aria-disabled="true" cl-hydrated type="available">
               <span style="color: green;">Available</span>
               ready to be shipped in
@@ -286,7 +286,7 @@ describe('index.e2e', () => {
             <cl-price-amount type="price" cl-hydrated></cl-price-amount>
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
-          <cl-availability cl-hydrated code="${codes.doNotTrack}">
+          <cl-availability cl-hydrated code="${codes.doNotTrack}" rule="cheapest">
             <cl-availability-status cl-hydrated type="available">
               <span style="color: green;">Available</span>
               ready to be shipped in


### PR DESCRIPTION
Closes #56

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Add `rule` prop to the `cl-availability` component.

This `rule` prop is used to determine the information that will be displayed. `cheapest` is the delivery lead time associated with the lower shipping method cost, `fastest` is the delivery lead time associated with the lower average time to delivery.


https://github.com/commercelayer/drop-in.js/assets/1681269/a23928ff-ae7a-4f6a-b7ad-ea707aaa4a65



## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
