### PR TITLE
Suggesting major version instead of freezing the version

### DIFF
--- a/packages/docs/.storybook/addon-version/Tool.tsx
+++ b/packages/docs/.storybook/addon-version/Tool.tsx
@@ -1,0 +1,22 @@
+import { A, IconButton, Separator } from '@storybook/components'
+import { BoxIcon } from '@storybook/icons'
+import React from 'react'
+import { ADDON_NAME, LINK_URL, TOOL_ID } from './constants'
+
+export const Tool = () => {
+  return (
+    <>
+      <Separator />
+      <IconButton
+        key={TOOL_ID}
+        title={ADDON_NAME}
+        active={false}
+        onClick={() => {
+          window.open(LINK_URL, '_blank')
+        }}
+      >
+        {/* DO NOT REMOVE - replace version */}v2.4.0
+      </IconButton>
+    </>
+  )
+}

--- a/packages/docs/.storybook/addon-version/constants.ts
+++ b/packages/docs/.storybook/addon-version/constants.ts
@@ -1,0 +1,4 @@
+export const ADDON_ID = 'addon-version'
+export const ADDON_NAME = 'Latest version'
+export const TOOL_ID = `${ADDON_ID}/tool`
+export const LINK_URL = 'https://github.com/commercelayer/drop-in.js/releases'

--- a/packages/docs/.storybook/addon-version/manager.tsx
+++ b/packages/docs/.storybook/addon-version/manager.tsx
@@ -1,0 +1,13 @@
+import { addons, types } from '@storybook/manager-api'
+import React from 'react'
+import { Tool } from './Tool'
+import { ADDON_ID, ADDON_NAME } from './constants'
+
+addons.register(ADDON_ID, () => {
+  addons.add(ADDON_ID, {
+    title: ADDON_NAME,
+    type: types.TOOL,
+    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+    render: () => <Tool />,
+  })
+})

--- a/packages/docs/.storybook/main.ts
+++ b/packages/docs/.storybook/main.ts
@@ -32,6 +32,7 @@ const storybookConfig: StorybookConfig = {
     require.resolve('./addon-drop-in-css/manager.tsx'),
     require.resolve('./addon-minicart-css/manager.tsx'),
     require.resolve('./addon-scope-selector/manager.tsx'),
+    require.resolve('./addon-version/manager.tsx'),
     require.resolve('./addon-gh-repository/manager.tsx'),
   ],
   framework: {

--- a/packages/docs/stories/getting-started.mdx
+++ b/packages/docs/stories/getting-started.mdx
@@ -9,7 +9,7 @@ import { getSelectedScopeValue } from '../.storybook/addon-scope-selector/consta
 
 Assuming you already have a Commerce Layer account ([sign up](https://dashboard.commercelayer.io/sign_up) if you don't — it's free!) and your organization properly set up and filled with real or sample data (check our [onboarding documentation](https://docs.commercelayer.io/core/welcome) for more information about that), you can get easily started with Commerce Layer `drop-in.js` in two simple steps:
 
-1. Import the library from the [CDN](https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2.4.0/dist/drop-in/drop-in.esm.js).
+1. Import the library from the [CDN](https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.esm.js).
 2. Declare a global variable called `commercelayerConfig` and set the following attributes.
 
 | Attribute            | Type   | Required | Description                                                                                                                                                                                                      |
@@ -24,7 +24,7 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
  The final result should be similar to the code snippet below:
 
 <Source language='html' dark code={`
-<script type="module" src="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2.4.0/dist/drop-in/drop-in.esm.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.esm.js"></script>
 
 <script>
   (function() {
@@ -39,6 +39,12 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
 </script>
 `} />
 
+<Alert title="Semantic versioning" type="info">
+  We follow [semantic versioning](https://docs.npmjs.com/about-semantic-versioning) for our releases.
+  We recommend using the latest major version, `drop-in.js@2`, to benefit from the newest improvements and fixes as they become available.
+  Alternatively, you can lock in a specific version. The latest release is `drop-in.js@2.4.0`.
+</Alert>
+
 ## Styling
 
 ### `drop-in.css`
@@ -46,7 +52,7 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
 The drop-in library is shipped unstyled, so that you can apply your own styles. We provide some simple styling. If you're happy with that or you just want to speed up the set up process just add an additional `link` tag to your HTML code as follows:
 
 <Source language='html' dark code={`
-<link href="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2.4.0/dist/drop-in/drop-in.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.css" rel="stylesheet" />
 `} />
 
 ### `minicart.css`
@@ -54,7 +60,7 @@ The drop-in library is shipped unstyled, so that you can apply your own styles. 
 The [minicart](?path=/docs/components-cart-cl-cart-minicart--docs) version of the cart is unstyled and hidden by default. Since its behavior is achieved mostly via CSS, you have to write your own to style it. You can start from scratch, or import a minimal set of styles and take it from there. To do that, just add an additional `link` tag to your HTML code as follows:
 
 <Source language='html' dark code={`
-<link href="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2.4.0/dist/drop-in/minicart.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/minicart.css" rel="stylesheet" />
 `} />
 
 <Alert title="Applying styles" type="info">

--- a/replace-jsdelivr.js
+++ b/replace-jsdelivr.js
@@ -4,30 +4,49 @@
  * This script will replace all "version number" occurrences from jsDelivr urls so that it will point to the latest version.
  * This script runs on "version lifecycle" - https://github.com/lerna/lerna/blob/main/commands/version/README.md#lifecycle-scripts
  * 
- * @example https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2.4.0/dist/drop-in/drop-in.esm.js
+ * @example https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.esm.js
+ * @example `drop-in.js@2`
+ * @example `drop-in.js@2.4.0`
  */
 
 const { sync } = require('replace-in-file')
 const { version } = require('./lerna.json')
 
-const options = {
-  dry: false,
-  files: [
-    './**/*.md*',
-    './**/*.ts*',
-    './**/*.js*'
-  ],
-  from: /(https:\/\/cdn.jsdelivr.net\/npm\/@commercelayer\/drop-in.js@)([0-9a-z\.\-]+)(\/)/g,
-  to: `$1${version}$3`
-}
+const [major, minor, patch] = version.split('.')
+
+/** @type { Pick<import('replace-in-file').ReplaceInFileConfig, 'from' | 'to'>[] } */
+const tasks = [
+  {
+    from: /(https:\/\/cdn.jsdelivr.net\/npm\/@commercelayer\/drop-in.js@)([0-9a-z\.\-]+)(\/)/g,
+    to: `$1${major}$3`
+  },
+  {
+    from: /`(drop-in.js@)([0-9]+)`/g,
+    to: `\`$1${major}\``
+  },
+  {
+    from: /`(drop-in.js@)([0-9a-z]+\.[0-9a-z]+\.[0-9a-z\-]+)`/g,
+    to: `\`$1${version}\``
+  }
+]
 
 try {
-  const results = sync(options)
-  const filteredResults = results.filter(r => r.hasChanged).map(r => r.file)
+  const results = tasks.flatMap(task => sync({
+    dry: false,
+    files: [
+      './**/*.md*',
+      './**/*.ts*',
+      './**/*.js*'
+    ],
+    ...task
+  }))
 
-  if (filteredResults.length > 0) {
+  const filteredResults = results.filter(r => r.hasChanged).map(r => r.file)
+  let uniqueFilteredResults = [...new Set(filteredResults)];
+
+  if (uniqueFilteredResults.length > 0) {
     console.group('Updating "jsDelivr" version:', )
-    filteredResults.forEach(r => {
+    uniqueFilteredResults.forEach(r => {
       console.info('→', r)
     })
     console.groupEnd()

--- a/replace-jsdelivr.js
+++ b/replace-jsdelivr.js
@@ -25,18 +25,29 @@ const tasks = [
     to: `\`$1${major}\``
   },
   {
-    from: /`(drop-in.js@)([0-9a-z]+\.[0-9a-z]+\.[0-9a-z\-]+)`/g,
+    from: /`(drop-in.js@)([0-9]+\.[0-9]+\.[0-9a-z\-]+)`/g,
     to: `\`$1${version}\``
+  },
+  {
+    from: /({\/\* DO NOT REMOVE - replace version \*\/}v)([0-9a-z\.\-]+)/g,
+    to: `$1${version}`
   }
 ]
 
 try {
   const results = tasks.flatMap(task => sync({
     dry: false,
+    ignore: [
+      './node_modules/**',
+      './**/node_modules/**',
+    ],
     files: [
       './**/*.md*',
       './**/*.ts*',
-      './**/*.js*'
+      './**/*.js*',
+
+      './packages/docs/.storybook/**/*.ts*',
+      './packages/docs/.storybook/**/*.js*',
     ],
     ...task
   }))


### PR DESCRIPTION
## What I did

We follow [semantic versioning](https://docs.npmjs.com/about-semantic-versioning) for our releases. We recommend using the latest major version, `drop-in.js@2` (instead of `drop-in.js@2.4.0`), to benefit from the newest improvements and fixes as they become available.

We updated all the examples with the major version.
