### PR TITLE
Add triple-slash directive for Astro and React

### DIFF
--- a/packages/docs/stories/getting-started.mdx
+++ b/packages/docs/stories/getting-started.mdx
@@ -27,15 +27,13 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
 <script type="module" src="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.esm.js"></script>
 
 <script>
-  (function() {
-    window.commercelayerConfig = {
-      clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
-      slug: 'drop-in-js',
-      scope: '${getSelectedScopeValue()}',
-      debug: 'all', // default is 'none'
-      orderReturnUrl: 'https://example.com' // optional
-    }
-  }());
+  window.commercelayerConfig = {
+    clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
+    slug: 'drop-in-js',
+    scope: '${getSelectedScopeValue()}',
+    debug: 'all', // default is 'none'
+    orderReturnUrl: 'https://example.com' // optional
+  }
 </script>
 `} />
 

--- a/packages/drop-in/jest.e2e.helpers.ts
+++ b/packages/drop-in/jest.e2e.helpers.ts
@@ -11,13 +11,11 @@ export function getCommerceLayerConfiguration({
 }: Partial<CommerceLayerConfig> = {}): string {
   return `
     <script>
-      (function() {
-        commercelayerConfig = {
-          clientId: '${clientId}',
-          slug: '${slug}',
-          scope: '${scope}'
-        }
-      }());
+      commercelayerConfig = {
+        clientId: '${clientId}',
+        slug: '${slug}',
+        scope: '${scope}'
+      }
     </script>
   `
 }

--- a/packages/drop-in/package.json
+++ b/packages/drop-in/package.json
@@ -27,7 +27,7 @@
     "drop-in"
   ],
   "scripts": {
-    "postinstall": "pnpm build",
+    "prepare": "pnpm build",
     "build": "stencil build --docs && pnpm build:sass",
     "build:sass": "sass --style compressed ./src/styles/:./dist/drop-in/",
     "build:watch": "stencil build --docs --watch",

--- a/packages/drop-in/src/apis/commercelayer/config.ts
+++ b/packages/drop-in/src/apis/commercelayer/config.ts
@@ -52,7 +52,6 @@ export function getConfig(): Config {
     )
   }
 
-  // @ts-expect-error We are accessing an unknown window object
   const commercelayerConfig: CommerceLayerConfig = window.commercelayerConfig
 
   if (typeof commercelayerConfig.clientId !== 'string') {

--- a/packages/drop-in/src/cart.html
+++ b/packages/drop-in/src/cart.html
@@ -33,15 +33,13 @@
     </script> -->
 
     <script>
-      (function() {
-        window.commercelayerConfig = {
-          clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
-          slug: 'drop-in-js',
-          scope: 'market:code:usa',
-          debug: 'all',
-          orderReturnUrl: 'https://example.com'
-        }
-      }());
+      window.commercelayerConfig = {
+        clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
+        slug: 'drop-in-js',
+        scope: 'market:code:usa',
+        debug: 'all',
+        orderReturnUrl: 'https://example.com'
+      }
     </script>
 
   </head>

--- a/packages/drop-in/src/client.d.ts
+++ b/packages/drop-in/src/client.d.ts
@@ -9,6 +9,7 @@
  */
 
 import { CommerceLayerConfig } from './apis/commercelayer/config'
+import { CLCustomEventDetailMap } from './apis/event'
 import { JSX as DropInJSX } from './components'
 
 export type { CommerceLayerConfig }
@@ -22,10 +23,10 @@ declare global {
     interface IntrinsicElements extends DropInElements { }
 
     type DropInElements = {
-      [Key in keyof DropInJSX.IntrinsicElements]: (
+      [key in keyof DropInJSX.IntrinsicElements]: (
         // @ts-expect-error This is a valid attribute
         & astroHTML.JSX.HTMLAttributes
-        & DropInJSX.IntrinsicElements[Key]
+        & DropInJSX.IntrinsicElements[key]
       )
     }
   }
@@ -34,11 +35,19 @@ declare global {
     interface IntrinsicElements extends DropInElements { }
 
     type DropInElements = {
-      [Key in keyof DropInJSX.IntrinsicElements]: (
+      [key in keyof DropInJSX.IntrinsicElements]: (
         // @ts-expect-error This is a valid attribute
         & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
-        & DropInJSX.IntrinsicElements[Key]
+        & DropInJSX.IntrinsicElements[key]
       )
     }
   }
+}
+
+type DropInDocumentEventMap = {
+  [key in keyof CLCustomEventDetailMap]: CustomEvent<CLCustomEventDetailMap[key]>
+}
+
+declare global {
+  interface DocumentEventMap extends DropInDocumentEventMap {}
 }

--- a/packages/drop-in/src/client.d.ts
+++ b/packages/drop-in/src/client.d.ts
@@ -1,0 +1,44 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Add the following triple-slash directive:
+ * ```ts
+ * /// <reference types="@commercelayer/drop-in.js" />
+ * ```
+ */
+
+import { CommerceLayerConfig } from './apis/commercelayer/config'
+import { JSX as DropInJSX } from './components'
+
+export type { CommerceLayerConfig }
+
+declare global {
+  interface Window {
+    commercelayerConfig: CommerceLayerConfig
+  }
+
+  module astroHTML.JSX {
+    interface IntrinsicElements extends DropInElements { }
+
+    type DropInElements = {
+      [Key in keyof DropInJSX.IntrinsicElements]: (
+        // @ts-expect-error This is a valid attribute
+        & astroHTML.JSX.HTMLAttributes
+        & DropInJSX.IntrinsicElements[Key]
+      )
+    }
+  }
+
+  module React.JSX {
+    interface IntrinsicElements extends DropInElements { }
+
+    type DropInElements = {
+      [Key in keyof DropInJSX.IntrinsicElements]: (
+        // @ts-expect-error This is a valid attribute
+        & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+        & DropInJSX.IntrinsicElements[Key]
+      )
+    }
+  }
+}

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -46,27 +46,25 @@
     </script>
 
     <script>
-      (function () {
-        // // stg
-        // window.commercelayerConfig = {
-        //     domain: 'commercelayer.co',
-        //     clientId: '',
-        //     slug: 'drop-in-js-stg',
-        //     scope: 'market:545',
-        //     debug: 'all',
-        //     orderReturnUrl: 'https://example.com'
-        //     // validScopes: ['market:545', 'market:1234', ''],
-        // };
+      // // stg
+      // window.commercelayerConfig = {
+      //     domain: 'commercelayer.co',
+      //     clientId: '',
+      //     slug: 'drop-in-js-stg',
+      //     scope: 'market:545',
+      //     debug: 'all',
+      //     orderReturnUrl: 'https://example.com'
+      //     // validScopes: ['market:545', 'market:1234', ''],
+      // };
 
-        // prd
-        window.commercelayerConfig = {
-          clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
-          slug: 'drop-in-js',
-          scope: 'market:code:usa',
-          debug: 'all',
-          orderReturnUrl: 'https://example.com',
-        };
-      })();
+      // prd
+      window.commercelayerConfig = {
+        clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
+        slug: 'drop-in-js',
+        scope: 'market:code:usa',
+        debug: 'all',
+        orderReturnUrl: 'https://example.com',
+      };
     </script>
   </head>
   <body>

--- a/packages/drop-in/src/index.ts
+++ b/packages/drop-in/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components'
+export * from './client'


### PR DESCRIPTION
## What I did

I added the triple-slash directive for Astro and React.

You just need to add the following directive:

```ts
/// <reference types="@commercelayer/drop-in.js" />
```

**Astro**: add the directive to the `env.d.ts` file.
**Next.js**: add the directive adding a [custom type declaration](https://nextjs.org/docs/pages/building-your-application/configuring/typescript#custom-type-declarations).

---

- autocompletion

  <img width="501" alt="Custom element autocompletion on Next.js" src="https://github.com/commercelayer/drop-in.js/assets/1681269/1e1d3cbe-2898-461b-86ca-8443619e62e7">

  <img width="1285" alt="Prop autocompletion on Next.js" src="https://github.com/commercelayer/drop-in.js/assets/1681269/6daa9c64-6e82-411e-befa-d63402f59f2b">

- documentation

  <img width="656" alt="Documentation on Astro" src="https://github.com/commercelayer/drop-in.js/assets/1681269/5d052689-62b8-4c8f-949f-7b610c3cc42f">

- configuration

  <img width="512" alt="Configuration on Astro" src="https://github.com/commercelayer/drop-in.js/assets/1681269/da87ab6a-bb7b-40d4-b861-6d3862fe5d76">

- custom events

  <img width="512" alt="autocomplete event name" src="https://github.com/commercelayer/drop-in.js/assets/1681269/f6096885-ba2b-4709-890b-45d467b66d2f">

  <img width="373" alt="autocomplete event detail" src="https://github.com/commercelayer/drop-in.js/assets/1681269/dbc03312-c5eb-48d6-b087-1ed96b44538b">

