### PR TITLE
Add `availability-with-info` type to the `cl-availability-status` component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ typings/
 # Nuxt.js build / generate output
 .nuxt
 dist
+dist-*
 
 # Gatsby files
 .cache/

--- a/packages/docs/stories/assets/constants.ts
+++ b/packages/docs/stories/assets/constants.ts
@@ -5,7 +5,7 @@ export const codes = {
   noDiscount: 'BACKPACKFFFFFF000000XXXX',
   outOfStock: '5PANECAP9D9CA1FFFFFFXXXX',
   doNotTrack: 'BOTT17OZFFFFFF000000XXXX',
-  doNotShip: 'DUFFLBAG000000FFFFFFXXXX',
+  digitalProduct: 'EBOOKECOMPLAYBOOKED1XXXX',
   subscription: 'POLOMXXX000000FFFFFFMXXX',
   bundleAvailable: 'CLGETTINGSTARTED',
   bundleOutOfStock: 'CLOUTOFSTOCK'

--- a/packages/docs/stories/assets/constants.ts
+++ b/packages/docs/stories/assets/constants.ts
@@ -5,6 +5,7 @@ export const codes = {
   noDiscount: 'BACKPACKFFFFFF000000XXXX',
   outOfStock: '5PANECAP9D9CA1FFFFFFXXXX',
   doNotTrack: 'BOTT17OZFFFFFF000000XXXX',
+  doNotShip: 'DUFFLBAG000000FFFFFFXXXX',
   subscription: 'POLOMXXX000000FFFFFFMXXX',
   bundleAvailable: 'CLGETTINGSTARTED',
   bundleOutOfStock: 'CLOUTOFSTOCK'

--- a/packages/docs/stories/availability/cl-availability-info.mdx
+++ b/packages/docs/stories/availability/cl-availability-info.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story, Controls } from '@storybook/blocks'
 import * as Stories from './cl-availability-info.stories.ts';
+import { Alert } from '../assets/components'
 
 <Meta of={Stories} />
 
@@ -7,11 +8,15 @@ import * as Stories from './cl-availability-info.stories.ts';
 
 As you saw in the [`cl-availability`](?path=/docs/components-availability-cl-availability--docs) component examples, `cl-availability-info` is a placeholder used to display the availability information in terms of delivery lead times, shipping methods, and related costs.
 
-You can choose which kind of data you want to show by using the `type` attribute of the component. If the selected product is out of stock, no information will be displayed and the component will be rendered as an empty box without any size. Give it a try here below:
+You can choose which kind of data you want to show by using the `type` attribute of the component. If the selected product is out of stock or is available but with no additional availablity information, nothing will be displayed and the component will be rendered as an empty box without any size. Give it a try here below:
 
 <Canvas of={Stories.Basic} />
 
 <Controls of={Stories.Basic} />
+
+<Alert title="Product availability" type="info">
+  We strongly recommend using the `cl-availability-info` component inside a `cl-availability-info` component of type `available-with-info` to be able to display the additional availability information only if it's present (e.g. *Shippable product* in the example above).
+</Alert>
 
 ### Multiple information
 

--- a/packages/docs/stories/availability/cl-availability-info.mdx
+++ b/packages/docs/stories/availability/cl-availability-info.mdx
@@ -15,7 +15,7 @@ You can choose which kind of data you want to show by using the `type` attribute
 <Controls of={Stories.Basic} />
 
 <Alert title="Product availability" type="info">
-  We strongly recommend using the `cl-availability-info` component inside a `cl-availability-info` component of type `available-with-info` to be able to display the additional availability information only if it's present (e.g. *Shippable product* in the example above).
+  We strongly recommend using the `cl-availability-info` component inside a `cl-availability-status` component of type `available-with-info` to be able to display the additional availability information only if it's present (e.g. *Shippable product* in the example above).
 </Alert>
 
 ### Multiple information

--- a/packages/docs/stories/availability/cl-availability-info.stories.ts
+++ b/packages/docs/stories/availability/cl-availability-info.stories.ts
@@ -5,18 +5,24 @@ import { create } from '../../utils'
 import { codes } from '../assets/constants'
 
 type Args = DropInArgs['cl-availability-info'] & {
-  ['Use an available product']: boolean
+  ['Product availability']: string
 }
 
 const meta: Meta<Args> = {
   title: 'Components/Availability/cl-availability-info',
   component: 'cl-availability-info',
   argTypes: {
-    'Use an available product': {
+    'Product availability': {
       description:
-        'Toggle this switch to swap from an out-of-stock to an available product in the example above.',
-      type: {
-        name: 'boolean'
+        'Select one of the options to swap between products with different availability in the example above.',
+      options: [codes.available, codes.digitalProduct, codes.outOfStock],
+      control: {
+        type: 'select',
+        labels: {
+          [codes.available]: 'Shippable product',
+          [codes.digitalProduct]: 'Digital product',
+          [codes.outOfStock]: 'Out of stock product'
+        }
       },
       table: {
         category: 'storybook'
@@ -29,17 +35,17 @@ export default meta
 
 export const Basic: StoryFn<Args> = (args) => {
   return create(html`
-    <cl-availability
-      code=${args['Use an available product']
-        ? codes.available
-        : codes.outOfStock}
-    >
-      <cl-availability-info type=${args.type ?? nothing}></cl-availability-info>
+    <cl-availability code=${args['Product availability']}>
+      <cl-availability-status type="available-with-info">
+        <cl-availability-info
+          type=${args.type ?? nothing}
+        ></cl-availability-info>
+      </cl-availability-status>
     </cl-availability>
   `)
 }
 Basic.args = {
-  'Use an available product': true,
+  'Product availability': codes.available,
   type: 'min-days'
 }
 

--- a/packages/docs/stories/availability/cl-availability-info.stories.ts
+++ b/packages/docs/stories/availability/cl-availability-info.stories.ts
@@ -47,13 +47,15 @@ export const Message: StoryFn<Args> = () => {
   return create(
     html`
       <cl-availability code=${codes.available}>
-        ready to be shipped in
-        <cl-availability-info type="min-days"></cl-availability-info
-        // eslint-disable-next-line prettier/prettier
-        >-<cl-availability-info type="max-days"></cl-availability-info>
-        days with
-        <cl-availability-info type="shipping-method-name"></cl-availability-info>
-        (<cl-availability-info type="shipping-method-price"></cl-availability-info>)
+        <cl-availability-status type="available-with-info">
+          ready to be shipped in
+          <cl-availability-info type="min-days"></cl-availability-info
+          // eslint-disable-next-line prettier/prettier
+          >-<cl-availability-info type="max-days"></cl-availability-info>
+          days with
+          <cl-availability-info type="shipping-method-name"></cl-availability-info>
+          (<cl-availability-info type="shipping-method-price"></cl-availability-info>)
+        </cl-availability-status>
       </cl-availability>
     `
   )

--- a/packages/docs/stories/availability/cl-availability-status.mdx
+++ b/packages/docs/stories/availability/cl-availability-status.mdx
@@ -7,7 +7,7 @@ import * as Stories from './cl-availability-status.stories.ts';
 
 As you saw in the [`cl-availability`](?path=/docs/components-availability-cl-availability--docs) component examples, `cl-availability-status` is a placeholder used to display the availability status.
 
-The inner message will be displayed based on the status type. If the `type` attribute is set to `available`, the message will be visible only if the product is available. Vice versa, if it is set to `unavailable`, the message will be visible only if the product is out of stock. Give it a try here below by playing with different combinations of the *Use an available product toggle* and the `type` attribute selector:
+The inner message will be displayed based on the status type. If the `type` attribute is set to `available`, the message will be visible only if the product is available. Vice versa, if it is set to `unavailable`, the message will be visible only if the product is out of stock. You can also set it to `available-with-info` in case you need to show additional information (if present) about the product availability (e.g. estimated delivery dates, shipping costs, etc.). In this case, the message will be visible only if the product is available and the related shipments come with available shipping methods that have delivery lead times specified. Give it a try here below by playing with different combinations of the *Product availability* and the `type` attribute selectors:
 
 <Canvas of={Stories.Basic} />
 

--- a/packages/docs/stories/availability/cl-availability-status.stories.ts
+++ b/packages/docs/stories/availability/cl-availability-status.stories.ts
@@ -5,18 +5,24 @@ import { create } from '../../utils'
 import { codes } from '../assets/constants'
 
 type Args = DropInArgs['cl-availability-status'] & {
-  ['Use an available product']: boolean
+  ['Product availability']: string
 }
 
 const meta: Meta<Args> = {
   title: 'Components/Availability/cl-availability-status',
   component: 'cl-availability-status',
   argTypes: {
-    'Use an available product': {
+    'Product availability': {
       description:
-        'Toggle this switch to swap from an out-of-stock to an available product in the example above.',
-      type: {
-        name: 'boolean'
+        'Select one of the options to swap between products with different availability in the example above.',
+      options: [codes.available, codes.digitalProduct, codes.outOfStock],
+      control: {
+        type: 'select',
+        labels: {
+          [codes.available]: 'Shippable product',
+          [codes.digitalProduct]: 'Digital product',
+          [codes.outOfStock]: 'Out of stock product'
+        }
       },
       table: {
         category: 'storybook'
@@ -29,11 +35,7 @@ export default meta
 
 export const Basic: StoryFn<Args> = (args) => {
   return create(html`
-    <cl-availability
-      code=${args['Use an available product']
-        ? codes.available
-        : codes.outOfStock}
-    >
+    <cl-availability code=${args['Product availability']}>
       <cl-availability-status type=${args.type ?? nothing}>
         • message
       </cl-availability-status>
@@ -41,6 +43,6 @@ export const Basic: StoryFn<Args> = (args) => {
   `)
 }
 Basic.args = {
-  'Use an available product': true,
+  'Product availability': codes.available,
   type: 'available'
 }

--- a/packages/docs/stories/availability/cl-availability.mdx
+++ b/packages/docs/stories/availability/cl-availability.mdx
@@ -15,8 +15,8 @@ This component is the owner of the availability information. It fetches the inve
 
 <Controls of={Stories.Basic} />
 
-<Alert title="Out of stock" type="info">
-  The pre-filled code in the *Control* field refers to an available product. Try to change it with an out-of-stock (e.g. <code>{codes.outOfStock}</code>) one and see how the component behaves in the example above.
+<Alert title="Product availability" type="info">
+  The pre-filled code in the *Control* field refers to an available product. Try to change it with an out-of-stock (e.g. <code>{codes.outOfStock}</code>) one or with a digital one that doesn't require to be shipped and consequently has no additional availability information (e.g. <code>{codes.digitalProduct}</code>) and see how the component behaves in the example above.
 </Alert>
 
 ### No code

--- a/packages/docs/stories/availability/cl-availability.stories.ts
+++ b/packages/docs/stories/availability/cl-availability.stories.ts
@@ -17,8 +17,10 @@ const Template: StoryFn<Args> = (args) => {
   return create(
     html`
       <cl-availability kind=${args.kind ?? nothing} code=${args.code ?? nothing} rule=${args.rule ?? nothing}>
-        <cl-availability-status type="available">
-          <span style="color: green;">• available</span>
+        <cl-availability-status type="available" style="color: green;">
+          • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info">
           ready to be shipped in
           <cl-availability-info type="min-days"></cl-availability-info
           // eslint-disable-next-line prettier/prettier

--- a/packages/drop-in/seed/data/prices.json
+++ b/packages/drop-in/seed/data/prices.json
@@ -313,5 +313,26 @@
     "amount_cents": 3110,
     "compare_at_amount_cents": 3550,
     "price_list": "price_list_3"
+  },
+  {
+    "reference": "price_751",
+    "sku_code": "EBOOKECOMPLAYBOOKED1XXXX",
+    "amount_cents": 3110,
+    "compare_at_amount_cents": 3550,
+    "price_list": "price_list_1"
+  },
+  {
+    "reference": "price_752",
+    "sku_code": "EBOOKECOMPLAYBOOKED1XXXX",
+    "amount_cents": 3110,
+    "compare_at_amount_cents": 3550,
+    "price_list": "price_list_2"
+  },
+  {
+    "reference": "price_753",
+    "sku_code": "EBOOKECOMPLAYBOOKED1XXXX",
+    "amount_cents": 3110,
+    "compare_at_amount_cents": 3550,
+    "price_list": "price_list_3"
   }
 ]

--- a/packages/drop-in/seed/data/shipping_categories.json
+++ b/packages/drop-in/seed/data/shipping_categories.json
@@ -2,5 +2,9 @@
   {
     "reference": "shipping_category_1",
     "name": "Merchandising"
+  },
+  {
+    "reference": "shipping_category_2",
+    "name": "Digital"
   }
 ]

--- a/packages/drop-in/seed/data/skus.json
+++ b/packages/drop-in/seed/data/skus.json
@@ -56,7 +56,6 @@
     "name": "Black Duffle Bag with White Logo",
     "description": "The perfect spacious bag no matter the occasion. It’s great for packing exercise gear when heading to the gym, or throwing in necessities and going on an adventure.",
     "image_url": "https://data.commercelayer.app/seed/images/skus/DUFFLBAG000000FFFFFFXXXX_FLAT.png",
-    "do_not_ship": true,
     "shipping_category": "shipping_category_1"
   },
   {
@@ -122,5 +121,14 @@
     "description": "This is THE classic t-shirt. Its fine jersey cotton construction makes it extremely soft and comfortable to wear, so it's a good choice for a day-to-day outfit — it's durable and can withstand several washings while retaining its shape and color.",
     "image_url": "https://data.commercelayer.app/seed/images/skus/TSHIRTMSFFFFFF000000XLXX_FLAT.png",
     "shipping_category": "shipping_category_1"
+  },
+  {
+    "reference": "sku_251",
+    "code": "EBOOKECOMPLAYBOOKED1XXXX",
+    "name": "The Ecommerce Playbook (Ebook ed.1)",
+    "description": "How to get started with a composable commerce approach, powered by Commerce Layer. Download the ebook for free.",
+    "image_url": "https://data.commercelayer.app/seed/images/skus/EBOOKECOMPLAYBOOKED1XXXX_FLAT.png",
+    "do_not_ship": true,
+    "shipping_category": "shipping_category_2"
   }
 ]

--- a/packages/drop-in/seed/data/skus.json
+++ b/packages/drop-in/seed/data/skus.json
@@ -56,6 +56,7 @@
     "name": "Black Duffle Bag with White Logo",
     "description": "The perfect spacious bag no matter the occasion. It’s great for packing exercise gear when heading to the gym, or throwing in necessities and going on an adventure.",
     "image_url": "https://data.commercelayer.app/seed/images/skus/DUFFLBAG000000FFFFFFXXXX_FLAT.png",
+    "do_not_ship": true,
     "shipping_category": "shipping_category_1"
   },
   {

--- a/packages/drop-in/seed/data/stock_items.json
+++ b/packages/drop-in/seed/data/stock_items.json
@@ -142,5 +142,17 @@
     "sku_code": "TSHIRTMSFFFFFF000000XLXX",
     "quantity": 166,
     "stock_location": "stock_location_2"
+  },
+  {
+    "reference": "stock_item_501",
+    "sku_code": "EBOOKECOMPLAYBOOKED1XXXX",
+    "quantity": 500,
+    "stock_location": "stock_location_1"
+  },
+  {
+    "reference": "stock_item_502",
+    "sku_code": "EBOOKECOMPLAYBOOKED1XXXX",
+    "quantity": 500,
+    "stock_location": "stock_location_2"
   }
 ]

--- a/packages/drop-in/seed/drop_in.json
+++ b/packages/drop-in/seed/drop_in.json
@@ -69,7 +69,8 @@
   {
     "resourceType": "shipping_categories",
     "referenceKeys": [
-      "shipping_category_1"
+      "shipping_category_1",
+      "shipping_category_2"
     ]
   },
   {

--- a/packages/drop-in/seed/reset_stock_items.json
+++ b/packages/drop-in/seed/reset_stock_items.json
@@ -6,8 +6,8 @@
       "stock_item_60",
       "stock_item_358",
       "stock_item_108",
-      "stock_item_41",
-      "stock_item_291"
+      "stock_item_501",
+      "stock_item_502"
     ]
   }
 ]

--- a/packages/drop-in/seed/reset_stock_items.json
+++ b/packages/drop-in/seed/reset_stock_items.json
@@ -5,7 +5,9 @@
       "stock_item_310",
       "stock_item_60",
       "stock_item_358",
-      "stock_item_108"
+      "stock_item_108",
+      "stock_item_41",
+      "stock_item_291"
     ]
   }
 ]

--- a/packages/drop-in/src/components.d.ts
+++ b/packages/drop-in/src/components.d.ts
@@ -57,7 +57,10 @@ export namespace Components {
         /**
           * The product availability status. It determines the visibility of the inner message.
          */
-        "type": 'available' | 'unavailable' | undefined;
+        "type": | 'available'
+    | 'available-with-info'
+    | 'unavailable'
+    | undefined;
     }
     interface ClCart {
         /**
@@ -278,7 +281,10 @@ declare namespace LocalJSX {
         /**
           * The product availability status. It determines the visibility of the inner message.
          */
-        "type": 'available' | 'unavailable' | undefined;
+        "type": | 'available'
+    | 'available-with-info'
+    | 'unavailable'
+    | undefined;
     }
     interface ClCart {
         /**

--- a/packages/drop-in/src/components/cl-availability-status/cl-availability-status.spec.tsx
+++ b/packages/drop-in/src/components/cl-availability-status/cl-availability-status.spec.tsx
@@ -24,6 +24,9 @@ describe('cl-availability-status.spec', () => {
           <cl-availability-status type="available">
             • available
           </cl-availability-status>
+          <cl-availability-status type="available-with-info">
+            • available with info
+          </cl-availability-status>
           <cl-availability-status type="unavailable">
             • out of stock
           </cl-availability-status>
@@ -36,6 +39,10 @@ describe('cl-availability-status.spec', () => {
         <cl-availability-status type="available" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
           • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
         </cl-availability-status>
         <cl-availability-status type="unavailable" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
@@ -79,6 +86,136 @@ describe('cl-availability-status.spec', () => {
           </mock:shadow-root>
           • available
         </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
+        </cl-availability-status>
+        <cl-availability-status type="unavailable" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • out of stock
+        </cl-availability-status>
+      </div>
+    `)
+  })
+
+  it('renders as available with info when product is available and has delivery lead times', async () => {
+    const { body, waitForChanges } = await newSpecPage({
+      components: [ClAvailabilityStatus],
+      html: `
+        <div>
+          <cl-availability-status type="available">
+            • available
+          </cl-availability-status>
+          <cl-availability-status type="available-with-info">
+            • available with info
+          </cl-availability-status>
+          <cl-availability-status type="unavailable">
+            • out of stock
+          </cl-availability-status>
+        </div>
+      `
+    })
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-status type="available" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
+        </cl-availability-status>
+        <cl-availability-status type="unavailable" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • out of stock
+        </cl-availability-status>
+      </div>
+    `)
+
+    const sku: Sku = {
+      id: 'ABC123',
+      code: 'ABC123',
+      name: 'ABC123',
+      type: 'skus',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      inventory: {
+        available: true,
+        quantity: 98,
+        levels: [
+          {
+            delivery_lead_times: [
+              {
+                min: {
+                  days: 5,
+                  hours: 5 * 24
+                },
+                max: {
+                  days: 10,
+                  hours: 10 * 24
+                },
+                shipping_method: {
+                  name: 'Standard',
+                  reference: 'reference-1',
+                  price_amount_cents: 700,
+                  formatted_price_amount: '$7.00',
+                  formatted_free_over_amount: null,
+                  free_over_amount_cents: null
+                }
+              },
+              {
+                min: {
+                  days: 6,
+                  hours: 6 * 24
+                },
+                max: {
+                  days: 7,
+                  hours: 7 * 24
+                },
+                shipping_method: {
+                  name: 'Express',
+                  reference: 'reference-2',
+                  price_amount_cents: 2000,
+                  formatted_price_amount: '$20.00',
+                  formatted_free_over_amount: null,
+                  free_over_amount_cents: null
+                }
+              }
+            ],
+            quantity: 98
+          }
+        ]
+      }
+    }
+
+    body.querySelectorAll('cl-availability-status').forEach((element) =>
+      element.dispatchEvent(
+        new CustomEvent<AvailabilityUpdateEventPayload>('availabilityUpdate', {
+          detail: {
+            sku,
+            rule: 'cheapest'
+          }
+        })
+      )
+    )
+
+    await waitForChanges()
+
+    expect(body).toEqualHtml(`
+      <div>
+        <cl-availability-status type="available">
+          <mock:shadow-root>
+            <slot></slot>
+          </mock:shadow-root>
+          • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info">
+          <mock:shadow-root>
+            <slot></slot>
+          </mock:shadow-root>
+          • available with info
+        </cl-availability-status>
         <cl-availability-status type="unavailable" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
           • out of stock
@@ -95,6 +232,9 @@ describe('cl-availability-status.spec', () => {
           <cl-availability-status type="available">
             • available
           </cl-availability-status>
+          <cl-availability-status type="available-with-info">
+            • available with info
+          </cl-availability-status>
           <cl-availability-status type="unavailable">
             • out of stock
           </cl-availability-status>
@@ -107,6 +247,10 @@ describe('cl-availability-status.spec', () => {
         <cl-availability-status type="available" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
           • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
         </cl-availability-status>
         <cl-availability-status type="unavailable" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
@@ -148,6 +292,10 @@ describe('cl-availability-status.spec', () => {
           <mock:shadow-root></mock:shadow-root>
           • available
         </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
+        </cl-availability-status>
         <cl-availability-status type="unavailable">
           <mock:shadow-root>
             <slot></slot>
@@ -166,6 +314,9 @@ describe('cl-availability-status.spec', () => {
           <cl-availability-status type="available">
             • available
           </cl-availability-status>
+          <cl-availability-status type="available-with-info">
+            • available with info
+          </cl-availability-status>
           <cl-availability-status type="unavailable">
             • out of stock
           </cl-availability-status>
@@ -178,6 +329,10 @@ describe('cl-availability-status.spec', () => {
         <cl-availability-status type="available" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
           • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
         </cl-availability-status>
         <cl-availability-status type="unavailable" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>
@@ -228,6 +383,10 @@ describe('cl-availability-status.spec', () => {
         <cl-availability-status aria-disabled="true" type="available">
           <mock:shadow-root></mock:shadow-root>
           • available
+        </cl-availability-status>
+        <cl-availability-status type="available-with-info" aria-disabled="true">
+          <mock:shadow-root></mock:shadow-root>
+          • available with info
         </cl-availability-status>
         <cl-availability-status type="unavailable" aria-disabled="true">
           <mock:shadow-root></mock:shadow-root>

--- a/packages/drop-in/src/components/cl-availability-status/cl-availability-status.tsx
+++ b/packages/drop-in/src/components/cl-availability-status/cl-availability-status.tsx
@@ -28,15 +28,24 @@ export class ClAvailabilityStatus {
    * The product availability status.
    * It determines the visibility of the inner message.
    */
-  @Prop({ reflect: true }) type!: 'available' | 'unavailable' | undefined
+  @Prop({ reflect: true }) type!:
+    | 'available'
+    | 'available-with-info'
+    | 'unavailable'
+    | undefined
 
   @State() available: boolean | undefined
+
+  @State() hasDeliveryLeadTimes: boolean | undefined
 
   @Listen('availabilityUpdate')
   availabilityUpdateHandler(
     event: CustomEvent<AvailabilityUpdateEventPayload>
   ): void {
     this.available = event.detail?.sku?.inventory?.available
+    this.hasDeliveryLeadTimes =
+      (event.detail?.sku?.inventory?.levels?.[0]?.delivery_lead_times?.length ??
+        0) > 0
   }
 
   async componentWillLoad(): Promise<void> {
@@ -55,7 +64,10 @@ export class ClAvailabilityStatus {
   render(): JSX.Element {
     if (
       (this.type === 'available' && this.available === true) ||
-      (this.type === 'unavailable' && this.available === false)
+      (this.type === 'unavailable' && this.available === false) ||
+      (this.type === 'available-with-info' &&
+        this.available === true &&
+        this.hasDeliveryLeadTimes === true)
     ) {
       return <slot></slot>
     }

--- a/packages/drop-in/src/components/cl-availability-status/readme.md
+++ b/packages/drop-in/src/components/cl-availability-status/readme.md
@@ -7,9 +7,9 @@
 
 ## Properties
 
-| Property            | Attribute | Description                                                                         | Type                                        | Default     |
-| ------------------- | --------- | ----------------------------------------------------------------------------------- | ------------------------------------------- | ----------- |
-| `type` _(required)_ | `type`    | The product availability status. It determines the visibility of the inner message. | `"available" \| "unavailable" \| undefined` | `undefined` |
+| Property            | Attribute | Description                                                                         | Type                                                                 | Default     |
+| ------------------- | --------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ----------- |
+| `type` _(required)_ | `type`    | The product availability status. It determines the visibility of the inner message. | `"available" \| "available-with-info" \| "unavailable" \| undefined` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/drop-in/src/index.e2e.ts
+++ b/packages/drop-in/src/index.e2e.ts
@@ -17,6 +17,7 @@ const codes = {
   noDiscount: 'BACKPACKFFFFFF000000XXXX',
   outOfStock: '5PANECAP9D9CA1FFFFFFXXXX',
   doNotTrack: 'BOTT17OZFFFFFF000000XXXX',
+  digitalProduct: 'EBOOKECOMPLAYBOOKED1XXXX',
   subscription: 'POLOMXXX000000FFFFFFMXXX',
   bundleAvailable: 'CLGETTINGSTARTED',
   bundleOutOfStock: 'CLOUTOFSTOCK'
@@ -76,6 +77,7 @@ const availableElements = getCodeElements(codes.available)
 const noDiscountElements = getCodeElements(codes.noDiscount)
 const outOfStockElements = getCodeElements(codes.outOfStock)
 const doNotTrackElements = getCodeElements(codes.doNotTrack)
+const digitalProductElements = getCodeElements(codes.digitalProduct)
 const subscriptionElements = getCodeElements(codes.subscription)
 const bundleAvailableElements = getCodeElements(codes.bundleAvailable)
 const bundleOutOfStockElements = getCodeElements(codes.bundleOutOfStock)
@@ -115,8 +117,8 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability code="${codes.available}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -139,8 +141,8 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability code="${codes.noDiscount}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -161,8 +163,8 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability code="${codes.outOfStock}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -185,8 +187,30 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability code="${codes.doNotTrack}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
+                ready to be shipped in
+                <cl-availability-info type="min-days"></cl-availability-info>
+                -
+                <cl-availability-info type="max-days"></cl-availability-info>
+                days with
+                <cl-availability-info type="shipping-method-name"></cl-availability-info>
+                (<cl-availability-info type="shipping-method-price"></cl-availability-info>)
+              </cl-availability-status>
+              <cl-availability-status type="unavailable">Out Of Stock</cl-availability-status>
+            </cl-availability>
+          </div>
+
+          <div>
+            <cl-add-to-cart
+              code="${codes.digitalProduct}">Add to cart</cl-add-to-cart>
+            <cl-price code="${codes.digitalProduct}">
+              <cl-price-amount type="price"></cl-price-amount>
+              <cl-price-amount type="compare-at"></cl-price-amount>
+            </cl-price>
+            <cl-availability code="${codes.digitalProduct}">
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -210,8 +234,8 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability code="${codes.subscription}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -235,8 +259,8 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability kind="bundle" code="${codes.bundleAvailable}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -260,8 +284,8 @@ describe('index.e2e', () => {
               <cl-price-amount type="compare-at"></cl-price-amount>
             </cl-price>
             <cl-availability kind="bundle" code="${codes.bundleOutOfStock}">
-              <cl-availability-status type="available">
-                <span style="color: green;">Available</span>
+              <cl-availability-status type="available" style="color: green;">Available<br /></cl-availability-status>
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>
                 -
@@ -305,8 +329,8 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="sku" cl-hydrated code="${codes.available}" rule="cheapest">
-            <cl-availability-status cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -326,8 +350,8 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="sku" cl-hydrated code="${codes.noDiscount}" rule="cheapest">
-            <cl-availability-status cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -347,8 +371,8 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="sku" cl-hydrated code="${codes.outOfStock}" rule="cheapest">
-            <cl-availability-status aria-disabled="true" cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -368,8 +392,29 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="sku" cl-hydrated code="${codes.doNotTrack}" rule="cheapest">
-            <cl-availability-status cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status cl-hydrated type="available-with-info">
+              ready to be shipped in
+              <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
+              -
+              <cl-availability-info cl-hydrated type="max-days"></cl-availability-info>
+              days with
+              <cl-availability-info cl-hydrated type="shipping-method-name"></cl-availability-info>
+              (<cl-availability-info cl-hydrated type="shipping-method-price"></cl-availability-info>)
+            </cl-availability-status>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="unavailable">Out Of Stock</cl-availability-status>
+          </cl-availability>
+        </div>
+
+        <div>
+          <cl-add-to-cart kind="sku" code="${codes.digitalProduct}" quantity="1" role="button" tabindex="0" cl-hydrated>Add to cart</cl-add-to-cart>
+          <cl-price kind="sku" code="${codes.digitalProduct}" cl-hydrated>
+            <cl-price-amount type="price" cl-hydrated></cl-price-amount>
+            <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
+          </cl-price>
+          <cl-availability kind="sku" cl-hydrated code="${codes.digitalProduct}" rule="cheapest">
+            <cl-availability-status cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -389,8 +434,8 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="sku" cl-hydrated code="${codes.subscription}" rule="cheapest">
-            <cl-availability-status cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -410,8 +455,8 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="bundle" cl-hydrated code="${codes.bundleAvailable}" rule="cheapest">
-            <cl-availability-status aria-disabled="true" cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -431,8 +476,8 @@ describe('index.e2e', () => {
             <cl-price-amount type="compare-at" cl-hydrated></cl-price-amount>
           </cl-price>
           <cl-availability kind="bundle" cl-hydrated code="${codes.bundleOutOfStock}" rule="cheapest">
-            <cl-availability-status aria-disabled="true" cl-hydrated type="available">
-              <span style="color: green;">Available</span>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available" style="color: green;">Available<br /></cl-availability-status>
+            <cl-availability-status aria-disabled="true" cl-hydrated type="available-with-info">
               ready to be shipped in
               <cl-availability-info cl-hydrated type="min-days"></cl-availability-info>
               -
@@ -667,6 +712,59 @@ describe('index.e2e', () => {
         <mock:shadow-root>
           $7.00
         </mock:shadow-root>
+      </cl-availability-info>
+    `)
+
+    /**
+     * EXPECTATIONS FOR "DIGITAL PRODUCT" PRODUCT
+     */
+
+    expect(await digitalProductElements.getPriceAmount(page)).toEqualHtml(`
+      <cl-price-amount cl-hydrated type="price">
+        <mock:shadow-root>
+          $31.10
+        </mock:shadow-root>
+      </cl-price-amount>
+    `)
+
+    expect(await digitalProductElements.getPriceCompareAtAmount(page))
+      .toEqualHtml(`
+      <cl-price-amount cl-hydrated type="compare-at">
+        <mock:shadow-root>
+          <s part="strikethrough">
+            $35.50
+          </s>
+        </mock:shadow-root>
+      </cl-price-amount>
+    `)
+
+    expect(await digitalProductElements.getAvailabilityInfoMinDays(page))
+      .toEqualHtml(`
+      <cl-availability-info cl-hydrated type="min-days">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-availability-info>
+    `)
+
+    expect(await digitalProductElements.getAvailabilityInfoMaxDays(page))
+      .toEqualHtml(`
+      <cl-availability-info cl-hydrated type="max-days">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-availability-info>
+    `)
+
+    expect(
+      await digitalProductElements.getAvailabilityInfoShippingMethodName(page)
+    ).toEqualHtml(`
+      <cl-availability-info cl-hydrated type="shipping-method-name">
+        <mock:shadow-root></mock:shadow-root>
+      </cl-availability-info>
+    `)
+
+    expect(
+      await digitalProductElements.getAvailabilityInfoShippingMethodPrice(page)
+    ).toEqualHtml(`
+      <cl-availability-info cl-hydrated type="shipping-method-price">
+        <mock:shadow-root></mock:shadow-root>
       </cl-availability-info>
     `)
 

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -163,7 +163,7 @@
             <cl-add-to-cart code="5PANECAP000000FFFFFFXXXX">Add to cart</cl-add-to-cart>
             <cl-availability code="5PANECAP000000FFFFFFXXXX" class="text-sm">
               <cl-availability-status type="available" style="color: #1fda8a">available<br /></cl-availability-status>
-              <cl-availability-status type="available">
+              <cl-availability-status type="available-with-info">
                 ready to be shipped in
                 <cl-availability-info type="min-days"></cl-availability-info>-<cl-availability-info
                   type="max-days"

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -142,6 +142,7 @@
                   <option value="5PANECAP9D9CA1FFFFFFXXXX">Out Of Stock</option>
                   <option value="GMUG11OZFFFFFF000000XXXX">Overselling</option>
                   <option value="BOTT17OZFFFFFF000000XXXX">Do Not Track</option>
+                  <option value="DUFFLBAG000000FFFFFFXXXX">Do Not Ship</option>
                   <option value="POLOMXXX000000FFFFFFMXXX" data-quantity="2" data-frequency="three-month">Subscription (3 months)</option>
                   <option value="SKU1234">Non-Existing SKU</option>
                   <option value="">Without Attributes</option>

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -142,7 +142,7 @@
                   <option value="5PANECAP9D9CA1FFFFFFXXXX">Out Of Stock</option>
                   <option value="GMUG11OZFFFFFF000000XXXX">Overselling</option>
                   <option value="BOTT17OZFFFFFF000000XXXX">Do Not Track</option>
-                  <option value="DUFFLBAG000000FFFFFFXXXX">Do Not Ship</option>
+                  <option value="EBOOKECOMPLAYBOOKED1XXXX">Digital Product</option>
                   <option value="POLOMXXX000000FFFFFFMXXX" data-quantity="2" data-frequency="three-month">Subscription (3 months)</option>
                   <option value="SKU1234">Non-Existing SKU</option>
                   <option value="">Without Attributes</option>


### PR DESCRIPTION
## What I did

The availability message for products without delivery lead times was broken as below:

<img width="310" alt="Broken availability message" src="https://github.com/commercelayer/drop-in.js/assets/1681269/8f1a3115-57a9-4e5f-8287-392f96a653a1">

\
We added the new type `availability-with-info` to the `cl-availability-status` component. This will render the inner content only when the product is available and there're availability information.

## How to test

```diff
  <cl-availability code="5PANECAP000000FFFFFFXXXX">
    <cl-availability-status type="available" style="color: green;">available<br /></cl-availability-status>
-   <cl-availability-status type="available">
+   <cl-availability-status type="available-with-info">
      ready to be shipped in
      <cl-availability-info type="min-days"></cl-availability-info>
      -
      <cl-availability-info type="max-days"></cl-availability-info>
      days
    </cl-availability-status>
    <cl-availability-status type="unavailable" style="color: red;">out of stock</cl-availability-status>
  </cl-availability>
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
