### PR TITLE
Add ability to set custom name and image when creating the line item

### DIFF
--- a/packages/docs/stories/add-to-cart/cl-add-to-cart.stories.ts
+++ b/packages/docs/stories/add-to-cart/cl-add-to-cart.stories.ts
@@ -19,6 +19,8 @@ const Template: StoryFn<Args> = (args) => {
       kind=${args.kind ?? nothing}
       code=${args.code ?? nothing}
       quantity=${args.quantity ?? nothing}
+      name=${args.name ?? nothing}
+      image-url=${args['image-url'] ?? nothing}
       frequency=${args.frequency ?? nothing}
     >
       Add to cart

--- a/packages/docs/stories/events.mdx
+++ b/packages/docs/stories/events.mdx
@@ -57,7 +57,7 @@ The returned `event.detail` contains the kind, code, and quantity of the added i
 
 | Attribute          | Type   | Value                      |
 |--------------------|--------|----------------------------|
-| **`request.args`** | Array  | `[kind: 'bundle' \| 'sku', code: string, quantity: number, options: { frequency?: string }]` | 
+| **`request.args`** | Array  | `[kind: 'bundle' \| 'sku', code: string, quantity: number, options: { name?: string; image_url?: string; frequency?: string }]` | 
 | **`response`**     | Object | [`LineItem`](https://docs.commercelayer.io/core/v/api-reference/line_items/object) |
 
 

--- a/packages/drop-in/src/apis/types.ts
+++ b/packages/drop-in/src/apis/types.ts
@@ -63,7 +63,7 @@ export type AddItem = (
   kind: 'bundle' | 'sku',
   code: string,
   quantity: number,
-  options?: Partial<Pick<LineItem, 'frequency'>>
+  options?: Partial<Pick<LineItem, 'name' | 'image_url' | 'frequency'>>
 ) => Promise<LineItem>
 
 export type GetToken = () => Promise<Token>

--- a/packages/drop-in/src/components.d.ts
+++ b/packages/drop-in/src/components.d.ts
@@ -16,10 +16,18 @@ export namespace Components {
          */
         "frequency": string | undefined;
         /**
+          * A custom image URL for the product or bundle that will be added to the cart. If not provided, the image URL will be taken from the item being added.
+         */
+        "imageUrl": string | undefined;
+        /**
           * Indicates whether the code refers to a `sku` or a `bundle`.
           * @default sku
          */
         "kind"?: 'sku' | 'bundle';
+        /**
+          * A custom name for the product or bundle that will be added to the cart. If not provided, the name will be taken from the item being added.
+         */
+        "name": string | undefined;
         /**
           * The number of units of the selected product you want to add to the shopping cart.
           * @default 1
@@ -240,10 +248,18 @@ declare namespace LocalJSX {
          */
         "frequency"?: string | undefined;
         /**
+          * A custom image URL for the product or bundle that will be added to the cart. If not provided, the image URL will be taken from the item being added.
+         */
+        "imageUrl"?: string | undefined;
+        /**
           * Indicates whether the code refers to a `sku` or a `bundle`.
           * @default sku
          */
         "kind"?: 'sku' | 'bundle';
+        /**
+          * A custom name for the product or bundle that will be added to the cart. If not provided, the name will be taken from the item being added.
+         */
+        "name"?: string | undefined;
         /**
           * The number of units of the selected product you want to add to the shopping cart.
           * @default 1

--- a/packages/drop-in/src/components/cl-add-to-cart/cl-add-to-cart.spec.tsx
+++ b/packages/drop-in/src/components/cl-add-to-cart/cl-add-to-cart.spec.tsx
@@ -206,6 +206,62 @@ describe('cl-add-to-cart.spec', () => {
     `)
   })
 
+  it('renders properly when "name" attribute is set', async () => {
+    jest
+      .spyOn(skus, 'getSku')
+      .mockImplementation(
+        async (sku: string) => await Promise.resolve(skuList[sku])
+      )
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CLAddToCart],
+      html: '<cl-add-to-cart code="AVAILABLE123" name="Custom name">Add to cart</cl-add-to-cart>'
+    })
+
+    root?.setAttribute('name', 'Nome personalizzato')
+
+    await waitForMs(11)
+
+    await waitForChanges()
+
+    expect(root).toEqualHtml(`
+      <cl-add-to-cart kind="sku" code="AVAILABLE123" name="Nome personalizzato" quantity="1" role="button" tabindex="0">
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+        Add to cart
+      </cl-add-to-cart>
+    `)
+  })
+
+  it('renders properly when "image-url" attribute is set', async () => {
+    jest
+      .spyOn(skus, 'getSku')
+      .mockImplementation(
+        async (sku: string) => await Promise.resolve(skuList[sku])
+      )
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CLAddToCart],
+      html: '<cl-add-to-cart code="AVAILABLE123" image-url="https://example.com/image-1">Add to cart</cl-add-to-cart>'
+    })
+
+    root?.setAttribute('image-url', 'https://example.com/image-2')
+
+    await waitForMs(11)
+
+    await waitForChanges()
+
+    expect(root).toEqualHtml(`
+      <cl-add-to-cart kind="sku" code="AVAILABLE123" image-url="https://example.com/image-2" quantity="1" role="button" tabindex="0">
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+        Add to cart
+      </cl-add-to-cart>
+    `)
+  })
+
   it('renders disabled when item is out of stock', async () => {
     jest
       .spyOn(skus, 'getSku')

--- a/packages/drop-in/src/components/cl-add-to-cart/cl-add-to-cart.tsx
+++ b/packages/drop-in/src/components/cl-add-to-cart/cl-add-to-cart.tsx
@@ -51,6 +51,18 @@ export class CLAddToCart {
   @Prop({ reflect: true, mutable: true }) quantity: number = 1
 
   /**
+   * A custom name for the product or bundle that will be added to the cart.
+   * If not provided, the name will be taken from the item being added.
+   */
+  @Prop({ reflect: true }) name: string | undefined
+
+  /**
+   * A custom image URL for the product or bundle that will be added to the cart.
+   * If not provided, the image URL will be taken from the item being added.
+   */
+  @Prop({ reflect: true }) imageUrl: string | undefined
+
+  /**
    * The frequency which generates a [subscription](https://docs.commercelayer.io/core/v/how-tos/placing-orders/subscriptions). The value must be supported by the associated subscription model.
    */
   @Prop({ reflect: true }) frequency: string | undefined
@@ -124,6 +136,8 @@ export class CLAddToCart {
   handleAddItem(): void {
     if (this.code !== undefined && this.canBeSold()) {
       addItem(this.kind ?? this.kindDefault, this.code, this.quantity, {
+        name: this.name,
+        image_url: this.imageUrl,
         frequency: this.frequency
       }).catch((error) => {
         throw error

--- a/packages/drop-in/src/components/cl-add-to-cart/readme.md
+++ b/packages/drop-in/src/components/cl-add-to-cart/readme.md
@@ -11,7 +11,9 @@
 | ------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
 | `code` _(required)_ | `code`      | The SKU or bundle code (i.e. the unique identifier of the product or bundle you want to add to the shopping cart).                                                                           | `string \| undefined`            | `undefined` |
 | `frequency`         | `frequency` | The frequency which generates a [subscription](https://docs.commercelayer.io/core/v/how-tos/placing-orders/subscriptions). The value must be supported by the associated subscription model. | `string \| undefined`            | `undefined` |
+| `imageUrl`          | `image-url` | A custom image URL for the product or bundle that will be added to the cart. If not provided, the image URL will be taken from the item being added.                                         | `string \| undefined`            | `undefined` |
 | `kind`              | `kind`      | Indicates whether the code refers to a `sku` or a `bundle`.                                                                                                                                  | `"bundle" \| "sku" \| undefined` | `'sku'`     |
+| `name`              | `name`      | A custom name for the product or bundle that will be added to the cart. If not provided, the name will be taken from the item being added.                                                   | `string \| undefined`            | `undefined` |
 | `quantity`          | `quantity`  | The number of units of the selected product you want to add to the shopping cart.                                                                                                            | `number`                         | `1`         |
 
 

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -142,6 +142,7 @@
                   <option value="BOTT17OZFFFFFF000000XXXX">Do Not Track</option>
                   <option value="EBOOKECOMPLAYBOOKED1XXXX">Digital Product</option>
                   <option value="POLOMXXX000000FFFFFFMXXX" data-quantity="2" data-frequency="three-month">Subscription (3 months)</option>
+                  <option value="5PANECAP000000FFFFFFXXXX" data-name="Amazing cap" data-image-url="https://i.ibb.co/TqQGpn6/Baseball-Cap.png">Custom name and image</option>
                   <option value="SKU1234">Non-Existing SKU</option>
                   <option value="">Without Attributes</option>
                 </select>
@@ -193,6 +194,8 @@
                 {
                   code: option.value,
                   quantity: parseInt(option.dataset.quantity),
+                  name: option.dataset.name,
+                  imageUrl: option.dataset.imageUrl,
                   frequency: option.dataset.frequency,
                   kind: option.dataset.kind,
                 }
@@ -204,9 +207,9 @@
             console.groupEnd()
 
             /**
-             * @type {(productCard: Element, options: { code: string; quantity?: number; frequency?: string; kind?: 'bundle' | 'sku'; description?: string; }) => void}
+             * @type {(productCard: Element, options: { code: string; quantity?: number; name?: string; imageUrl?: string; frequency?: string; kind?: 'bundle' | 'sku'; description?: string; }) => void}
              */
-            function updateProductCard(productCard, { code, quantity, description, frequency, kind }) {
+            function updateProductCard(productCard, { code, quantity, description, name, imageUrl, frequency, kind }) {
               productCard.querySelector('[data-id="pc--sku"]').innerText = code;
               productCard.querySelector('[data-id="pc--img"]').src = kind === 'bundle'
                 ? 'https://res.cloudinary.com/commercelayer/image/upload/v1681465805/demo-store/assets/white-glossy-mug-15oz-valentines-day.png'
@@ -217,6 +220,8 @@
               productCard.querySelector('cl-add-to-cart').code = code;
               productCard.querySelector('cl-add-to-cart').quantity = isNaN(quantity) || quantity == null ? 1 : quantity;
               productCard.querySelector('[data-id="pc--quantity"]').value = isNaN(quantity) || quantity == null ? 1 : quantity;
+              productCard.querySelector('cl-add-to-cart').name = name;
+              productCard.querySelector('cl-add-to-cart').imageUrl = imageUrl;
               productCard.querySelector('cl-add-to-cart').frequency = frequency;
               productCard.querySelector('cl-availability').kind = kind ?? null;
               productCard.querySelector('cl-availability').code = code;
@@ -250,10 +255,12 @@
             select.addEventListener('change', function (event) {
               const code = event.currentTarget.value;
               const quantity = parseInt(event.currentTarget.selectedOptions[0].dataset.quantity)
+              const name = event.currentTarget.selectedOptions[0].dataset.name
+              const imageUrl = event.currentTarget.selectedOptions[0].dataset.imageUrl
               const frequency = event.currentTarget.selectedOptions[0].dataset.frequency
               const kind = event.currentTarget.selectedOptions[0].dataset.kind
 
-              updateProductCard(productCard, { code, quantity, frequency, kind })
+              updateProductCard(productCard, { code, quantity, name, imageUrl, frequency, kind })
             })
           </script>
         </div>
@@ -263,9 +270,9 @@
         </div>
 
         <script>
-          // codes.forEach(([description, { code, quantity, frequency, kind }]) => {
+          // codes.forEach(([description, { code, quantity, name, imageUrl, frequency, kind }]) => {
           //   const newProductCard = productCard.cloneNode(true)
-          //   updateProductCard(newProductCard, { code, quantity, description, frequency, kind })
+          //   updateProductCard(newProductCard, { code, quantity, description, name, imageUrl, frequency, kind })
           //   document.getElementById('product-list').append(newProductCard)
           // })
         </script>


### PR DESCRIPTION
## What I did

I added ability to set custom name and image when creating the line item.

```html
<cl-add-to-cart code="5PANECAP000000FFFFFFXXXX" name="Custom name" image-url="https://example.com/image.jpg">
  Add to cart
</cl-add-to-cart>
```

https://deploy-preview-87--commercelayer-drop-in-js.netlify.app/?path=/docs/components-add-to-cart-cl-add-to-cart--docs