### PR TITLE
Ability to set custom order attributes when creating the order

### DIFF
--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -147,7 +147,6 @@ const preview: Preview = {
       return story()
     },
     (story) => {
-      // @ts-expect-error
       window.commercelayerConfig = createConfig(getSelectedScopeValue())
 
       return story()

--- a/packages/docs/stories/assets/constants.ts
+++ b/packages/docs/stories/assets/constants.ts
@@ -1,3 +1,5 @@
+import type { CommerceLayerConfig } from '@commercelayer/drop-in.js'
+
 export const codes = {
   nonexisting: 'NONEXISTINGSKU',
   available: '5PANECAP000000FFFFFFXXXX',
@@ -12,8 +14,7 @@ export const codes = {
 }
 
 // // stg
-// // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-// export const createConfig = (scope: string) => ({
+// export const createConfig = (scope: string): CommerceLayerConfig => ({
 //   clientId: 'gQMSINLyMm2TrZo0UGEEdubC7uSgm9-',
 //   scope,
 //   debug: 'all',
@@ -21,8 +22,7 @@ export const codes = {
 // })
 
 // prd
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const createConfig = (scope: string) => ({
+export const createConfig = (scope: string): CommerceLayerConfig => ({
   clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
   scope,
   debug: 'all'

--- a/packages/docs/stories/getting-started.mdx
+++ b/packages/docs/stories/getting-started.mdx
@@ -12,16 +12,15 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
 1. Import the library from the [CDN](https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.esm.js).
 2. Declare a global variable called `commercelayerConfig` and set the following attributes.
 
-| Attribute            | Type   | Required | Description                                                                                                                                                                                                                                    |
-|----------------------|--------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **`clientId`**       | String |     ✓    | Your [sales channel](https://docs.commercelayer.io/core/applications#sales-channel) client ID. You can find it in your application details page on your dashboard.                                                                             |
-| **`scope`**          | String |     ✓    | Your sales channel [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) (use it to restrict the dataset of your application). You can find the allowed scopes in your application details page on your dashboard.   |
-| `debug`              | String |          | The debug level. Can be one of `none` or `all`. Default is `none`.                                                                                                                                                                             |
-| `languageCode`       | String |          | The preferred language code (ISO 639-1) to be used when communicating with the customer. If the language is supported, the hosted checkout will be localized accordingly. Default is `en`.                                                     |
-| `orderReturnUrl`     | String |          | The URL the cart's *Continue shopping* button points to. This is also used in the thank you page.                                                                                                                                              |
+| Attribute                   | Type   | Required | Description                                                                                                                                                                                                                                    |
+|-----------------------------|--------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`clientId`**              | String |     ✓    | Your [sales channel](https://docs.commercelayer.io/core/applications#sales-channel) client ID. You can find it in your application details page on your dashboard.                                                                             |
+| **`scope`**                 | String |     ✓    | Your sales channel [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) (use it to restrict the dataset of your application). You can find the allowed scopes in your application details page on your dashboard.   |
+| `debug`                     | String |          | The debug level. Can be one of `none` or `all`. Default is `none`.                                                                                                                                                                             |
+| `defaultAttributes.orders`  | Object |          | Default [attributes](https://docs.commercelayer.io/core/api-reference/orders/object) when creating an `orders` resource type. See the snippet below for a working example.                                                                     |
 
 
- The final result should be similar to the code snippet below:
+The final result should be similar to the code snippet below:
 
 <Source language='html' dark code={`
 <script type="module" src="https://cdn.jsdelivr.net/npm/@commercelayer/drop-in.js@2/dist/drop-in/drop-in.esm.js"></script>
@@ -31,8 +30,21 @@ Assuming you already have a Commerce Layer account ([sign up](https://dashboard.
     clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
     scope: '${getSelectedScopeValue()}',
     debug: 'all', // default is 'none'
-    languageCode: 'en', // default is 'en'
-    orderReturnUrl: 'https://example.com' // optional
+    defaultAttributes: {
+      orders: {
+        /**
+         * The preferred language code (ISO 639-1) to be used when communicating with the customer.
+         * If the language is supported, the hosted checkout will be localized accordingly.
+         * @default 'en'
+         */
+        language_code: 'en',
+        /**
+         * The URL the cart's *Continue shopping* button points to. This is also used in the thank you page.
+         * @optional
+         */
+        return_url: 'https://example.com'
+      }
+    }
   }
 </script>
 `} />
@@ -74,9 +86,9 @@ The [minicart](?path=/docs/components-cart-cl-cart-minicart--docs) version of th
 
 ## Need help?
 
-- Join [Commerce Layer's Slack community](https://slack.commercelayer.app).
-- Open a new [Q&A discussion](https://github.com/commercelayer/drop-in.js/discussions/categories/q-a)
-- Ping us [on Twitter](https://twitter.com/commercelayer).
+- Join [Commerce Layer's Discord community](https://discord.gg/commercelayer).
+- Open a new [Q&A discussion](https://github.com/commercelayer/drop-in.js/discussions/categories/q-a).
+- Ping us on [Bluesky](https://bsky.app/profile/commercelayer.io), [X](https://x.com/commercelayer), or [LinkedIn](https://www.linkedin.com/company/commerce-layer).
 - Is there a bug? Create an [issue](https://github.com/commercelayer/drop-in.js/issues) on this repository.
 
 

--- a/packages/drop-in/README.md
+++ b/packages/drop-in/README.md
@@ -41,7 +41,7 @@ For a constantly updated list of the available and soon-to-come micro frontends 
 
 - Join [Commerce Layer's Discord community](https://discord.gg/commercelayer).
 - Open a new [Q&A discussion](https://github.com/commercelayer/drop-in.js/discussions/categories/q-a).
-- Ping us on [Bluesky](https://bsky.app/profile/commercelayer.io), [X (formerly Twitter)](https://x.com/commercelayer), or [LinkedIn](https://www.linkedin.com/company/commerce-layer).
+- Ping us on [Bluesky](https://bsky.app/profile/commercelayer.io), [X](https://x.com/commercelayer), or [LinkedIn](https://www.linkedin.com/company/commerce-layer).
 - Is there a bug? Create an [issue](https://github.com/commercelayer/drop-in.js/issues) on this repository.
 
 ## License

--- a/packages/drop-in/src/apis/commercelayer/cart.ts
+++ b/packages/drop-in/src/apis/commercelayer/cart.ts
@@ -23,10 +23,9 @@ async function createEmptyCart(): Promise<Order> {
   const client = await createClient(config)
   const token = await getAccessToken(config)
 
-  const order = await client.orders.create({
-    return_url: config.orderReturnUrl,
-    language_code: config.languageCode
-  })
+  const order = await client.orders.create(
+    config.defaultAttributes?.orders ?? {}
+  )
 
   if (token.type === 'guest') {
     setCartId(order.id)

--- a/packages/drop-in/src/cart.html
+++ b/packages/drop-in/src/cart.html
@@ -37,7 +37,11 @@
         clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
         scope: 'market:code:usa',
         debug: 'all',
-        orderReturnUrl: 'https://example.com'
+        defaultAttributes: {
+          orders: {
+            return_url: 'https://example.com'
+          }
+        }
       }
     </script>
 

--- a/packages/drop-in/src/index.html
+++ b/packages/drop-in/src/index.html
@@ -48,12 +48,16 @@
     <script>
       // // stg
       // window.commercelayerConfig = {
-      //     domain: 'commercelayer.co',
-      //     clientId: '',
-      //     scope: 'market:code:usa',
-      //     debug: 'all',
-      //     orderReturnUrl: 'https://example.com'
-      //     // validScopes: ['market:545', 'market:1234', ''],
+      //   domain: 'commercelayer.co',
+      //   clientId: '',
+      //   scope: 'market:code:usa',
+      //   debug: 'all',
+      //   defaultAttributes: {
+      //     orders: {
+      //       return_url: 'https://example.com'
+      //     }
+      //   }
+      //   // validScopes: ['market:545', 'market:1234', ''],
       // };
 
       // prd
@@ -61,7 +65,11 @@
         clientId: 'kuSKPbeKbU9LG9LjndzieKWRcfiXFuEfO0OYHXKH9J8',
         scope: 'market:code:usa',
         debug: 'all',
-        orderReturnUrl: 'https://example.com',
+        defaultAttributes: {
+          orders: {
+            return_url: 'https://example.com'
+          }
+        }
       };
     </script>
   </head>

--- a/packages/drop-in/src/utils/logger.spec.ts
+++ b/packages/drop-in/src/utils/logger.spec.ts
@@ -4,15 +4,13 @@ import { log } from './logger'
 function injectConfig({
   clientId = '1234',
   scope = 'market:code:usa',
-  debug,
-  orderReturnUrl
+  debug
 }: Partial<Config>): void {
   Object.defineProperty(window, 'commercelayerConfig', {
     value: {
       clientId,
       scope,
-      debug,
-      orderReturnUrl
+      debug
     }
   })
 }


### PR DESCRIPTION
## What I did

I added the ability to set custom order attributes when creating the order.

```html
<script>
  window.commercelayerConfig = {

    . . .

    defaultAttributes: {
      /**
       * Default attributes when creating an `orders` resource type.
       * @see https://docs.commercelayer.io/core/api-reference/orders/object
       */
      orders: {
        /**
         * The preferred language code (ISO 639-1) to be used when communicating with the customer.
         * If the language is supported, the hosted checkout will be localized accordingly.
         * @default 'en'
         */
        language_code: 'en',
        /**
         * The URL the cart's *Continue shopping* button points to. This is also used in the thank you page.
         * @optional
         */
        return_url: 'https://example.com'
      }
    }
  }
</script>
```

## :warning: Deprecation notice

- **`languageCode`** is deprecated and it will be removed in the next major version. Use `defaultAttributes.orders.language_code` instead.
- **`orderReturnUrl`** is deprecated and it will be removed in the next major version. Use `defaultAttributes.orders.return_url` instead.