### PR TITLE
Add `commercelayerConfig.version` to check the library version

### DIFF
--- a/packages/drop-in/src/apis/commercelayer/config.ts
+++ b/packages/drop-in/src/apis/commercelayer/config.ts
@@ -11,6 +11,12 @@ import { createClient, getAccessToken } from "./client"
 
 export interface CommerceLayerConfig {
   /**
+   * The version of the library.
+   * This is automatically set by the build process and should not be manually specified.
+   */
+  version: "drop-in.js@2.16.0"
+
+  /**
    * The client ID (from you API credentials).
    * @see https://docs.commercelayer.io/core/authentication/client-credentials
    */
@@ -90,6 +96,9 @@ export function getConfig(): Config {
       `"window.commercelayerConfig" is required.\n${documentationLink}\n`,
     )
   }
+
+  // NOTE: This is automatically set by the build process and should not be manually specified.
+  window.commercelayerConfig.version = "drop-in.js@2.16.0"
 
   const commercelayerConfig: CommerceLayerConfig = window.commercelayerConfig
 

--- a/replace-jsdelivr.js
+++ b/replace-jsdelivr.js
@@ -15,7 +15,7 @@
  */
 
 import { replaceInFileSync } from 'replace-in-file'
-import lernaJson from './lerna.json' assert { type: 'json' }
+import lernaJson from './lerna.json' with { type: 'json' }
 
 const [major, minor, patch] = lernaJson.version.split('.')
 
@@ -32,6 +32,10 @@ const tasks = [
   {
     from: /`(drop-in.js@)([0-9]+\.[0-9]+\.[0-9a-z\-]+)`/g,
     to: `\`$1${lernaJson.version}\``
+  },
+  {
+    from: /\"(drop-in.js@)([0-9]+\.[0-9]+\.[0-9a-z\-]+)\"/g,
+    to: `\"$1${lernaJson.version}\"`
   },
   {
     from: /({\/\* DO NOT REMOVE - replace version \*\/}v)([0-9a-z\.\-]+)/g,


### PR DESCRIPTION
## What I did

I added a `commercelayerConfig.version` to check the library version. This variable is set at built time and can be used at runtime to check which version is currently used in a website.

<img width="245" height="73" alt="commercelayerConfig.version in action" src="https://github.com/user-attachments/assets/13af4b22-9efe-4ffd-b1ee-a92e7cdd0a58" />
