### PR TITLE
Avoid copying full dist folder when building docs

### DIFF
--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -1,3 +1,4 @@
 storybook-static/
 public/*.css*
 public/dist/
+public/drop-in/

--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -170,7 +170,11 @@ const preview: Preview = {
     (story) => {
       const script = document.createElement("script")
       script.type = "module"
-      script.src = "dist/drop-in/drop-in.esm.js"
+
+      // This script is existing in the public folder thanks to the "build:copy" script,
+      // which is run in parallel with Storybook in development and before Storybook build in production
+      script.src = "drop-in/drop-in.esm.js"
+
       document.head.appendChild(script)
 
       return story()

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -4,7 +4,7 @@
   "version": "2.26.0",
   "scripts": {
     "start": "concurrently -n copy,sass,app -c 'bgMagenta,bgMagenta,bgMagenta' 'pnpm build:copy:watch' 'pnpm build:sass:watch' 'storybook dev -p 6006'",
-    "build:copy": "cp -r ../drop-in/dist public/",
+    "build:copy": "cp -r ../drop-in/dist/drop-in public/",
     "build:copy:watch": "nodemon --watch ./node_modules/@commercelayer/drop-in.js/dist/drop-in/drop-in.esm.js --exec 'pnpm build:copy'",
     "build:sass": "sass ./stories/assets/styles/:./public/",
     "build:sass:watch": "nodemon --watch ./node_modules/@commercelayer/drop-in.js -e scss --exec 'pnpm build:sass'",


### PR DESCRIPTION
## What I did

Avoid copying full `dist` folder when building docs.